### PR TITLE
Support single path ingestion and remove legacy alias

### DIFF
--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2,7 +2,7 @@ import sys
 import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from core.ingest import ingest
+from core.ingestion import ingest
 
 # Test a local file
 print("Testing file ingestion...")

--- a/tests/test_ingest_api.py
+++ b/tests/test_ingest_api.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.ingestion import ingest
+
+
+def test_ingest_accepts_single_path(tmp_path, monkeypatch):
+    sample = tmp_path / "sample.txt"
+    sample.write_text("hello")
+
+    # Stub out external dependencies used during ingestion
+    monkeypatch.setattr("core.ingestion.index_documents", lambda chunks: None)
+    monkeypatch.setattr("core.ingestion.index_chunks", lambda chunks: None)
+    class DummyTask:
+        app = type("obj", (), {"conf": type("obj", (), {"broker_url": ""})()})
+        @staticmethod
+        def delay(*args, **kwargs):
+            pass
+    monkeypatch.setattr("core.ingestion.embed_and_index_chunks", DummyTask())
+    monkeypatch.setattr("core.ingestion.is_file_up_to_date", lambda checksum: False)
+
+    result_str = ingest(str(sample))
+    result_list = ingest([str(sample)])
+
+    assert result_str == result_list
+    assert result_str and result_str[0]["path"] == os.path.normpath(str(sample)).replace("\\", "/")


### PR DESCRIPTION
## Summary
- allow ingestion API to accept a single file path or iterable of paths
- drop unused `core.ingest` shim; import `ingest` from `core.ingestion` directly in tests and helpers
- cover ingestion entrypoint with a unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68965dc862e4832ab2990f0e3c92a008