### PR TITLE
Ensure top_k controls retrieval limit

### DIFF
--- a/core/query.py
+++ b/core/query.py
@@ -65,8 +65,10 @@ def answer_question(
     with start_span("Retriever", RETRIEVER) as span:
         try:
             span.set_attribute(INPUT_VALUE, rewritten_query)
+            top_results = retrieve_hybrid(
+                rewritten_query, top_k_each=20, final_k=top_k
+            )
             span.set_attribute("top_k", top_k)
-            top_results = retrieve_hybrid(rewritten_query, top_k_each=20, final_k=5)
             span.set_attribute("results_found", len(top_results))
 
             retrieved_summary = [

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,59 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.query import answer_question
+
+
+def test_retrieval_limit_matches_top_k(monkeypatch):
+    spans = []
+
+    class DummySpan:
+        def __init__(self):
+            self.attrs = {}
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def set_attribute(self, key, value):
+            self.attrs[key] = value
+        def set_status(self, status):
+            pass
+
+    def dummy_start_span(name, kind):
+        span = DummySpan()
+        spans.append(span)
+        return span
+
+    call_args = {}
+    def mock_retrieve(query, top_k_each=20, final_k=5):
+        call_args['final_k'] = final_k
+        return [
+            {
+                'text': f'doc{i}',
+                'path': f'path{i}',
+                'chunk_index': i,
+                'score': 1.0,
+                'page': i + 1,
+                'location_percent': i * 10,
+            }
+            for i in range(final_k)
+        ]
+
+    def mock_rewrite(question, temperature=0.15):
+        return {'rewritten': question}
+
+    def mock_ask_llm(*args, **kwargs):
+        return 'answer'
+
+    monkeypatch.setattr('core.query.start_span', dummy_start_span)
+    monkeypatch.setattr('core.query.retrieve_hybrid', mock_retrieve)
+    monkeypatch.setattr('core.query.rewrite_query', mock_rewrite)
+    monkeypatch.setattr('core.query.ask_llm', mock_ask_llm)
+
+    answer_question('question', top_k=4)
+
+    retrieval_span = spans[0]
+    assert call_args['final_k'] == 4
+    assert retrieval_span.attrs['top_k'] == 4
+    assert retrieval_span.attrs['results_found'] == 4


### PR DESCRIPTION
## Summary
- Ensure `answer_question` respects `top_k` by passing it as `final_k` to `retrieve_hybrid`
- Add unit test verifying retrieval limit and span attributes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689686709a3c832ab43d511b1368d2ea