### PR TITLE
Use Celery for async document ingestion

### DIFF
--- a/pages/1_Ingest_Documents.py
+++ b/pages/1_Ingest_Documents.py
@@ -1,6 +1,9 @@
+import time
 import streamlit as st
 import pandas as pd
-from core.ingestion import ingest
+from celery.result import AsyncResult
+from worker.celery_worker import app
+from config import EMBEDDING_BATCH_SIZE
 from ui.ingestion_ui import run_file_picker, run_folder_picker
 from tracing import start_span, CHAIN, INPUT_VALUE, OUTPUT_VALUE, STATUS_OK
 
@@ -9,7 +12,7 @@ st.title("📥 Ingest Documents")
 
 col1, col2 = st.columns([1, 1], gap="small")
 
-selected_files = []
+selected_files: list[str] = []
 with col1:
     if st.button("📄 Select File(s)"):
         selected_files = run_file_picker()
@@ -18,52 +21,50 @@ with col2:
         selected_files = run_folder_picker()
 
 if selected_files:
-    st.success(f"Found {len(selected_files)} path(s).")
-    status_table = st.empty()
-    status_line = st.empty()
-    progress_bar = st.progress(0)
-    eta_display = st.empty()
-    df = pd.DataFrame({"Selected Path": [p.replace("\\", "/") for p in selected_files]})
-    status_table.dataframe(df, height=300)
+    st.session_state["selected_files"] = selected_files
 
-    def update_progress(done: int, total: int, elapsed: float):
-        progress_bar.progress(done / total)
-        if done:
-            eta = (elapsed / done) * (total - done)
-            eta_display.text(
-                f"{done}/{total} files ingested... (elapsed: {elapsed:.1f}s, ETA: {eta:.1f}s)"
-            )
-        else:
-            eta_display.text(
-                f"{done}/{total} files ingested... (elapsed: {elapsed:.1f}s)"
-            )
+files = st.session_state.get("selected_files", [])
+
+if files and "task_id" not in st.session_state:
+    st.success(f"Found {len(files)} path(s).")
+    df = pd.DataFrame({"Selected Path": [p.replace('\\', '/') for p in files]})
+    st.dataframe(df, height=300)
 
     with start_span("Ingestion chain", CHAIN) as span:
-        if len(selected_files) > 5:
-            preview = selected_files[:5] + [
-                f"... and {len(selected_files) - 5} more not shown here"
-            ]
-        else:
-            preview = selected_files
-            
+        preview = files[:5] + [f"... and {len(files) - 5} more not shown here"] if len(files) > 5 else files
         span.set_attribute(INPUT_VALUE, preview)
-        results = ingest(selected_files, progress_callback=update_progress)
-
-        successes = [r for r in results if r["success"]]
-        failures = [(r["path"], r["status"]) for r in results if not r["success"]]
-        span.set_attribute("indexed_files", len(successes))
-        span.set_attribute("failed_files", len(failures))
-        span.set_attribute("failed_files_details", str(failures))
-        span.set_attribute(OUTPUT_VALUE, f"{len(successes)} indexed, {len(failures)} failed")
+        async_result = app.send_task(
+            "core.ingestion_tasks.ingest_paths",
+            args=[files],
+            kwargs={
+                "force": False,
+                "replace": True,
+                "batch_size": EMBEDDING_BATCH_SIZE,
+            },
+        )
+        st.session_state["task_id"] = async_result.id
+        span.set_attribute(OUTPUT_VALUE, f"task_id={async_result.id}")
         span.set_status(STATUS_OK)
 
-    status_line.success(f"✅ Indexed {len(successes)} / {len(results)} file(s).")
-
-    summary_df = pd.DataFrame(
-        {
-            "File": [r["path"] for r in results],
-            "Status": [("✅" if r["success"] else "❌") + " " + r["status"] for r in results],
-            "Num. Chunks": [r.get("num_chunks", 0) for r in results],
-        }
-    )
-    status_table.dataframe(summary_df, height=300)
+if "task_id" in st.session_state:
+    task_id = st.session_state["task_id"]
+    res = AsyncResult(task_id, app=app)
+    st.write(f"Task state: {res.state}")
+    progress_bar = st.progress(0)
+    info = res.info or {}
+    total = info.get("total_files") or 1
+    done = info.get("files_done", 0)
+    progress_bar.progress(done / total)
+    st.write(f"{done}/{total} files processed")
+    if res.state == "SUCCESS":
+        st.success("✅ Ingestion complete. Embedding will continue in the background.")
+        del st.session_state["task_id"]
+        st.session_state.pop("selected_files", None)
+    else:
+        if st.button("Cancel Task"):
+            res.revoke(terminate=True, signal="SIGTERM")
+            del st.session_state["task_id"]
+            st.session_state.pop("selected_files", None)
+        else:
+            time.sleep(1)
+            st.experimental_rerun()


### PR DESCRIPTION
## Summary
- Integrate Celery into document ingestion page
- Submit file ingestion jobs to Celery and track task progress
- Allow cancelling running ingestion tasks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68968f4a7318832abc9533813318d08d