### PR TITLE
Autodiscover ingestion tasks in Celery worker

### DIFF
--- a/worker/celery_worker.py
+++ b/worker/celery_worker.py
@@ -8,3 +8,5 @@ app.config_from_object("config")
 
 # Autodiscover tasks from your main project
 app.autodiscover_tasks(["core"], related_name="embedding_tasks")
+app.autodiscover_tasks(["core"], related_name="ingestion_tasks")
+


### PR DESCRIPTION
## Summary
- Autodiscover ingestion tasks alongside embedding tasks in the Celery worker so ingestion job definitions are registered.

## Testing
- `pytest`
- `docker compose build celery` *(fails: command not found: docker)*
- `CELERY_BROKER_URL=memory:// python - <<'PY'
from worker.celery_worker import app
app.loader.import_default_modules()
print([t for t in sorted(app.tasks.keys()) if 'ingest' in t or 'embed' in t])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68972eba80a8832aaffeb86b2140cbc7