### PR TITLE
fix: reference path in Qdrant count helper

### DIFF
--- a/utils/qdrant_utils.py
+++ b/utils/qdrant_utils.py
@@ -57,7 +57,7 @@ def index_chunks(chunks: List[Dict[str, Any]]) -> bool:
 
 def count_qdrant_chunks_by_path(path: str) -> Optional[int]:
     """
-    Return the number of chunks in Qdrant matching the given checksum.
+    Return the number of chunks in Qdrant matching the given path.
     """
     try:
         result = client.count(
@@ -73,7 +73,7 @@ def count_qdrant_chunks_by_path(path: str) -> Optional[int]:
         )
         return result.count
     except Exception as e:
-        logger.error("❌ Qdrant count error for checksum=%s: %s", path, e)
+        logger.error("❌ Qdrant count error for path=%s: %s", path, e)
         return None
 
 


### PR DESCRIPTION
## Summary
- clarify docstring for `count_qdrant_chunks_by_path`
- log path in Qdrant count errors

## Testing
- `PYTHONPATH=$PWD pytest pages/2_index_viewer.py::count_qdrant_chunks_by_path -q` *(fails: ConnectionError: Failed to establish a new connection: [Errno 111] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689b855b7c0c832a9032ff4a46a28012