### PR TITLE
chore: add dev requirements and test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ The system is built from modular, testable components:
    streamlit run main.py
    ```
 
+### Run tests
+
+Install development requirements and run the test suite:
+
+```bash
+pip install -r requirements/shared.txt -r requirements/dev.txt
+pytest
+```
+
 ---
 
 ## 📌 Current Status

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,4 @@
+# Development dependencies
+pytest==7.4.*
+pytest-cov==4.1.*
+pytest-mock==3.14.*

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+pip install -r requirements/shared.txt -r requirements/dev.txt
+pytest --cov


### PR DESCRIPTION
## Summary
- add dev requirements for pytest and mocking utilities
- document how to install dev dependencies and run tests
- provide script to install dependencies and execute test suite

## Testing
- `./scripts/test.sh` *(fails: ModuleNotFoundError: No module named 'ftfy')*


------
https://chatgpt.com/codex/tasks/task_e_689b97291d0c832aa47c7dbabb0f5c0c