### PR TITLE
Test install app and worker requirements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,8 +38,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
-            requirements/shared.txt
-            requirements/dev.txt
+              requirements/shared.txt
+              requirements/dev.txt
+              requirements/app.txt
+              requirements/worker.txt
 
       - name: Run tests
         shell: bash

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,6 +10,20 @@ python -m venv .venv
 source .venv/bin/activate
 
 python -m pip install --upgrade pip wheel setuptools
+# Ensure app environment installs cleanly
+echo "Installing app requirements"
+if ! python -m pip install -r requirements/app.txt; then
+  echo "Failed to install app requirements" >&2
+  exit 1
+fi
+
+# Ensure worker environment installs cleanly
+echo "Installing worker requirements"
+if ! python -m pip install -r requirements/worker.txt; then
+  echo "Failed to install worker requirements" >&2
+  exit 1
+fi
+
 # Install runtime deps used by tests + dev tools
 python -m pip install -r requirements/shared.txt -r requirements/dev.txt
 


### PR DESCRIPTION
## Summary
- run app and worker pip install during tests so failures surface quickly
- cache app and worker requirements in test workflow

## Testing
- `bash scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_689cbf44a098832a86cce2d579d8f727