### PR TITLE
chore: ignore local virtual environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,3 +31,4 @@ Thumbs.db
 data/
 datasets/
 downloads/
+.venv/


### PR DESCRIPTION
## Summary
- add `.venv/` to `.dockerignore`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'ftfy', No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_689cbf2dce2c832aa2d4da9012319ea9