### PR TITLE
Add comprehensive tests to raise coverage

### DIFF
--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -1,0 +1,22 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import importlib
+import logging
+import os
+import config
+
+
+def test_env_helpers(monkeypatch):
+    monkeypatch.delenv("TEST_BOOL", raising=False)
+    assert config._env_bool("TEST_BOOL", True) is True
+    monkeypatch.setenv("TEST_BOOL", "off")
+    assert config._env_bool("TEST_BOOL", True) is False
+
+    monkeypatch.setenv("TEST_INT", "not-int")
+    assert config._env_int("TEST_INT", 5) == 5
+
+
+def test_logger_handler_added(monkeypatch):
+    monkeypatch.setattr(logging.Logger, "hasHandlers", lambda self: False)
+    importlib.reload(config)
+    assert config.logger.handlers

--- a/tests/test_embeddings_module.py
+++ b/tests/test_embeddings_module.py
@@ -1,0 +1,27 @@
+import pytest
+from core.embeddings import embed_texts
+import requests
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+    def json(self):
+        return self._data
+    def raise_for_status(self):
+        pass
+
+
+def test_embed_texts_success(monkeypatch):
+    def fake_post(url, json, timeout):
+        return DummyResponse({"embeddings": [[0.1, 0.2]]})
+    monkeypatch.setattr(requests, "post", fake_post)
+    result = embed_texts(["hello"], batch_size=1)
+    assert result == [[0.1, 0.2]]
+
+
+def test_embed_texts_failure(monkeypatch):
+    def fake_post(url, json, timeout):
+        raise requests.RequestException("boom")
+    monkeypatch.setattr(requests, "post", fake_post)
+    with pytest.raises(RuntimeError):
+        embed_texts(["hi"])

--- a/tests/test_file_loader_extra.py
+++ b/tests/test_file_loader_extra.py
@@ -1,0 +1,70 @@
+from core.file_loader import _load_txt_with_fallbacks, load_documents
+from langchain_core.documents import Document
+
+
+class AutoLoader:
+    def __init__(self, path, autodetect_encoding=False, encoding=None):
+        self.autodetect_encoding = autodetect_encoding
+        self.encoding = encoding
+        self.path = path
+
+    def load(self):
+        if self.autodetect_encoding:
+            return [Document(page_content="auto", metadata={"source": self.path})]
+        if self.encoding == "utf-8":
+            return [Document(page_content="utf8", metadata={"source": self.path})]
+        raise ValueError("bad encoding")
+
+
+class FailingLoader(AutoLoader):
+    def load(self):
+        raise ValueError("fail")
+
+
+def test_load_txt_autodetect(monkeypatch, tmp_path):
+    file_path = tmp_path / "doc.txt"
+    file_path.write_text("hello")
+    monkeypatch.setattr("core.file_loader.TextLoader", AutoLoader)
+    docs = _load_txt_with_fallbacks(str(file_path))
+    assert docs[0].metadata["encoding"] == "autodetect"
+
+
+def test_load_txt_fallback_and_salvage(monkeypatch, tmp_path):
+    file_path = tmp_path / "doc.txt"
+    file_path.write_text("hello")
+
+    class FallbackLoader:
+        def __init__(self, path, autodetect_encoding=False, encoding=None):
+            self.autodetect_encoding = autodetect_encoding
+            self.encoding = encoding
+            self.path = path
+        def load(self):
+            if self.autodetect_encoding:
+                raise TypeError("no autodetect")
+            raise ValueError("bad")
+
+    monkeypatch.setattr("core.file_loader.TextLoader", FallbackLoader)
+    docs = _load_txt_with_fallbacks(str(file_path))
+    assert docs[0].metadata["encoding"].startswith("utf-8")
+
+
+def test_load_documents_branches(monkeypatch, tmp_path):
+    txtfile = tmp_path / "a.txt"
+    txtfile.write_text("hi")
+    monkeypatch.setattr("core.file_loader._load_txt_with_fallbacks", lambda p: [Document(page_content="x")])
+    docs = load_documents(str(txtfile))
+    assert docs and docs[0].page_content == "x"
+
+    monkeypatch.setattr("core.file_loader.PyPDFLoader", lambda path: FailingLoader(path))
+    assert load_documents(str(tmp_path / "a.pdf")) == []
+
+    class DocxLoader:
+        def __init__(self, path):
+            self.path = path
+        def load(self):
+            return [Document(page_content="docx")]
+    monkeypatch.setattr("core.file_loader.Docx2txtLoader", DocxLoader)
+    docs = load_documents(str(tmp_path / "a.docx"))
+    assert docs and docs[0].page_content == "docx"
+
+    assert load_documents(str(tmp_path / "a.xyz")) == []

--- a/tests/test_file_utils_extra.py
+++ b/tests/test_file_utils_extra.py
@@ -1,0 +1,24 @@
+import os
+from utils.file_utils import (
+    compute_checksum,
+    normalize_path,
+    hash_path,
+    get_file_size,
+    get_file_timestamps,
+)
+
+
+def test_file_utils(tmp_path):
+    file_path = tmp_path / "example.txt"
+    file_path.write_text("content")
+
+    checksum = compute_checksum(str(file_path))
+    assert len(checksum) == 64
+
+    assert normalize_path("a\\b/c") == "a/b/c"
+
+    assert hash_path("abc")
+
+    assert get_file_size("does-not-exist") == 0
+    ts = get_file_timestamps("does-not-exist")
+    assert ts == {"created": "", "modified": ""}

--- a/tests/test_llm_module.py
+++ b/tests/test_llm_module.py
@@ -1,0 +1,47 @@
+import json
+import requests
+import pytest
+from core import llm
+
+class DummyResponse:
+    def __init__(self, data, status_code=200):
+        self._data = data
+        self.status_code = status_code
+        self.text = json.dumps(data)
+    def json(self):
+        return self._data
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError("error")
+
+def test_get_available_models(monkeypatch):
+    def fake_get(url, timeout):
+        return DummyResponse({"model_names": ["m1", "m2"]})
+    monkeypatch.setattr(requests, "get", fake_get)
+    models = llm.get_available_models()
+    assert models == ["m1", "m2"]
+
+def test_get_available_models_error(monkeypatch):
+    def fake_get(url, timeout):
+        raise requests.RequestException("boom")
+    monkeypatch.setattr(requests, "get", fake_get)
+    models = llm.get_available_models()
+    assert models == []
+
+def test_ask_llm_chat_and_completion(monkeypatch):
+    def fake_post(endpoint, json=None, timeout=None):
+        if endpoint == llm.LLM_CHAT_ENDPOINT:
+            return DummyResponse({"choices": [{"message": {"content": "hi</s>"}}]})
+        return DummyResponse({"choices": [{"text": "hello"}]})
+    monkeypatch.setattr(requests, "post", fake_post)
+    chat = llm.ask_llm([{"role": "user", "content": "hi"}], mode="chat")
+    assert chat.startswith("hi")
+    comp = llm.ask_llm("test prompt", mode="completion")
+    assert comp == "hello"
+
+def test_ask_llm_error(monkeypatch):
+    def fake_post(*args, **kwargs):
+        raise requests.RequestException("fail")
+    monkeypatch.setattr(requests, "post", fake_post)
+    result = llm.ask_llm("prompt")
+    assert result == "[LLM Error]"

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1,0 +1,26 @@
+import pytest
+from core.query_rewriter import rewrite_query
+
+
+def test_rewrite_query_rewritten(monkeypatch):
+    def fake_ask_llm(**kwargs):
+        return '{"rewritten": "Ali BSc study location"}'
+    monkeypatch.setattr("core.query_rewriter.ask_llm", fake_ask_llm)
+    result = rewrite_query("where did ali do his bsc studies")
+    assert result == {"rewritten": "Ali BSc study location"}
+
+
+def test_rewrite_query_clarify(monkeypatch):
+    def fake_ask_llm(**kwargs):
+        return '{"clarify": "Who are you referring to?"}'
+    monkeypatch.setattr("core.query_rewriter.ask_llm", fake_ask_llm)
+    result = rewrite_query("where did he do his bsc studies")
+    assert result == {"clarify": "Who are you referring to?"}
+
+
+def test_rewrite_query_error(monkeypatch):
+    def fake_ask_llm(**kwargs):
+        raise RuntimeError("fail")
+    monkeypatch.setattr("core.query_rewriter.ask_llm", fake_ask_llm)
+    result = rewrite_query("bad query")
+    assert "Error" in result

--- a/tests/test_tracing_utils.py
+++ b/tests/test_tracing_utils.py
@@ -1,0 +1,22 @@
+from tracing import record_span_error, StatusCode, Status
+
+
+class DummySpan:
+    def __init__(self):
+        self.exc = None
+        self.status = None
+
+    def record_exception(self, exc):
+        self.exc = exc
+
+    def set_status(self, status):
+        self.status = status
+
+
+def test_record_span_error():
+    span = DummySpan()
+    err = ValueError("bad")
+    record_span_error(span, err)
+    assert span.exc is err
+    assert isinstance(span.status, Status)
+    assert span.status.status_code == StatusCode.ERROR


### PR DESCRIPTION
## Summary
- Add tests for embedding API helper covering success and failure scenarios
- Test file utilities, tracing error recording, query rewriting, file loading branches, config helpers, and LLM client
- Raise repository test coverage from 55% to 66%

## Testing
- `pytest --maxfail=1 --disable-warnings -q`
- `pytest --maxfail=1 --disable-warnings --cov --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_689cdae98db0832aa7474b01d895dade