### PR TITLE
Sanitize file utility paths using normalize_path

### DIFF
--- a/tests/test_file_utils_extra.py
+++ b/tests/test_file_utils_extra.py
@@ -14,11 +14,16 @@ def test_file_utils(tmp_path):
 
     checksum = compute_checksum(str(file_path))
     assert len(checksum) == 64
+    alt_path = str(file_path).replace(os.sep, "\\")
+    assert compute_checksum(alt_path) == checksum
 
     assert normalize_path("a\\b/c") == "a/b/c"
 
     assert hash_path("abc")
 
     assert get_file_size("does-not-exist") == 0
+    assert get_file_size("does\\not\\exist") == 0
     ts = get_file_timestamps("does-not-exist")
+    assert ts == {"created": "", "modified": ""}
+    ts = get_file_timestamps("does\\not\\exist")
     assert ts == {"created": "", "modified": ""}

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -2,9 +2,18 @@ import os
 import hashlib
 from datetime import datetime
 
+__all__ = [
+    "compute_checksum",
+    "normalize_path",
+    "hash_path",
+    "get_file_size",
+    "get_file_timestamps",
+]
+
 
 def compute_checksum(path: str) -> str:
     """Compute SHA256 checksum of a file."""
+    path = normalize_path(path)
     sha256 = hashlib.sha256()
     with open(path, "rb") as f:
         while chunk := f.read(8192):
@@ -24,6 +33,7 @@ def hash_path(path: str) -> str:
 
 def get_file_size(path: str) -> int:
     """Return file size in bytes, or 0 if unavailable."""
+    path = normalize_path(path)
     try:
         return os.path.getsize(path)
     except OSError:
@@ -34,6 +44,7 @@ def get_file_timestamps(path: str) -> dict:
     """
     Returns creation and modification timestamps in ISO format.
     """
+    path = normalize_path(path)
     try:
         stat = os.stat(path)
         created = datetime.fromtimestamp(stat.st_ctime)


### PR DESCRIPTION
## Summary
- Sanitize path inputs in `compute_checksum`, `get_file_size`, and `get_file_timestamps` by normalizing paths up front
- Export file utility functions via `__all__` for reuse across the codebase
- Add tests covering Windows-style paths for checksum, size, and timestamp helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce4a21bf8832a837912d455c7a3ab