### PR TITLE
Add extra tests for LLM and OpenSearch utilities

### DIFF
--- a/tests/test_llm_module_extra.py
+++ b/tests/test_llm_module_extra.py
@@ -1,0 +1,73 @@
+import json
+import requests
+from core import llm
+
+class DummyResponse:
+    def __init__(self, data, status_code=200):
+        self._data = data
+        self.status_code = status_code
+        self.text = json.dumps(data)
+    def json(self):
+        return self._data
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError("boom")
+
+
+def test_check_llm_status_variants(monkeypatch):
+    # 200 with no model
+    def get_info(url, timeout):
+        return DummyResponse({"model_name": None})
+    monkeypatch.setattr(requests, "get", get_info)
+    status = llm.check_llm_status()
+    assert status["server_online"] is True
+    assert status["model_loaded"] is False
+    assert status["active"] is False
+    assert "No LLM model" in status["status_message"]
+
+    # 200 with model
+    def get_info_loaded(url, timeout):
+        return DummyResponse({"model_name": "m1"})
+    monkeypatch.setattr(requests, "get", get_info_loaded)
+    status = llm.check_llm_status()
+    assert status["server_online"] and status["model_loaded"]
+    assert status["active"] is True
+
+    # timeout / error
+    def get_fail(url, timeout):
+        raise requests.Timeout()
+    monkeypatch.setattr(requests, "get", get_fail)
+    status = llm.check_llm_status()
+    assert status["server_online"] is False
+    assert status["active"] is False
+
+
+def test_ask_llm_payload_and_error(monkeypatch):
+    captured = {}
+    def fake_post(endpoint, json=None, timeout=None):
+        captured["endpoint"] = endpoint
+        captured["json"] = json
+        if endpoint == llm.LLM_CHAT_ENDPOINT:
+            return DummyResponse({"choices": [{"message": {"content": "hi"}}]})
+        if endpoint == llm.LLM_COMPLETION_ENDPOINT:
+            return DummyResponse({"choices": [{"text": "done"}]})
+        return DummyResponse({}, status_code=500)
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    chat = llm.ask_llm([{"role": "user", "content": "h"}], mode="chat", temperature=0.1, max_tokens=5)
+    assert chat == "hi"
+    assert captured["endpoint"] == llm.LLM_CHAT_ENDPOINT
+    assert captured["json"]["messages"]
+    assert captured["json"]["temperature"] == 0.1
+    assert captured["json"]["max_tokens"] == 5
+
+    comp = llm.ask_llm("prompt", mode="completion", model="m1")
+    assert comp == "done"
+    assert captured["endpoint"] == llm.LLM_COMPLETION_ENDPOINT
+    assert captured["json"]["model"] == "m1"
+
+    def fail_post(*args, **kwargs):
+        raise requests.RequestException("x")
+    monkeypatch.setattr(requests, "post", fail_post)
+    err = llm.ask_llm("p")
+    assert err == "[LLM Error]"

--- a/tests/test_opensearch_utils_extra.py
+++ b/tests/test_opensearch_utils_extra.py
@@ -1,0 +1,92 @@
+import types
+import logging
+import utils.opensearch_utils as osu
+
+class FakeIndices:
+    def __init__(self, exists=False):
+        self.exists_flag = exists
+        self.created = []
+    def exists(self, index):
+        return self.exists_flag
+    def create(self, index, body):
+        self.created.append((index, body))
+
+class FakeClient:
+    def __init__(self):
+        self.indices = FakeIndices()
+        self.bulk_ops = []
+        self.deleted = []
+    def bulk(self, body, params):
+        self.bulk_ops.append(body)
+        items = []
+        for op, doc in zip(body[::2], body[1::2]):
+            if doc.get('doc', {}).get('fail'):
+                items.append({'update': {'error': 'x'}})
+            else:
+                items.append({'update': {'result': 'updated'}})
+        return {'items': items}
+    def delete_by_query(self, index, body, params):
+        self.deleted.append((index, body))
+        q = body['query']
+        if 'terms' in q:
+            return {'deleted': len(q['terms']['checksum'])}
+        return {'deleted': len(q['bool']['should'])}
+    def search(self, index, body):
+        return {'hits': {'hits': [
+            {'_id': '1', '_score': 1.0, '_source': {'path': 'p', 'checksum': 'c', 'text': 't', 'chunk_index':0, 'modified_at':'2020'}},
+            {'_id': '2', '_score': 0.5, '_source': {'path': 'p2', 'checksum': 'c2', 'text': 't2', 'chunk_index':1, 'modified_at':'2019'}},
+        ]}}
+
+
+def test_ensure_index_noop(monkeypatch):
+    client = FakeClient()
+    client.indices.exists_flag = True
+    monkeypatch.setattr(osu, 'get_client', lambda: client)
+    osu.ensure_index_exists()
+    assert client.indices.created == []
+
+
+def test_bulk_index_partial_failure(monkeypatch, caplog):
+    client = FakeClient()
+    monkeypatch.setattr(osu, 'get_client', lambda: client)
+    def fake_bulk(client, actions):
+        return (1, ['err'])
+    monkeypatch.setattr(osu, 'helpers', types.SimpleNamespace(bulk=fake_bulk))
+    caplog.set_level(logging.ERROR)
+    osu.index_documents([{ 'id':'1','text':'a'}])
+    assert any('OpenSearch indexing failed' in r.message for r in caplog.records)
+
+
+def test_set_has_embedding_partial_error(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(osu, 'get_client', lambda: client)
+    updated, errors = osu.set_has_embedding_true_by_ids(['a','b'])
+    assert updated == 2
+    assert errors == 0
+    # include failing doc
+    def bulk_fail(body, params):
+        return {'items':[{'update':{'result':'updated'}},{'update':{'error':'x'}}]}
+    client.bulk = bulk_fail
+    updated, errors = osu.set_has_embedding_true_by_ids(['a','b'])
+    assert updated == 1 and errors == 1
+
+
+def test_delete_by_checksum_and_path(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(osu, 'get_client', lambda: client)
+    deleted = osu.delete_files_by_checksum(['x','x','y'])
+    assert deleted == 2
+    assert client.deleted
+    client.deleted.clear()
+    pairs = [('a','c'),('a','c'),('b','d')]
+    deleted = osu.delete_files_by_path_checksum(pairs)
+    assert deleted == 2
+    assert client.deleted
+
+
+def test_get_files_by_checksum(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(osu, 'get_client', lambda: client)
+    files = osu.get_files_by_checksum('c')
+    assert files[0]['path'] == 'p'
+    assert files[0]['num_chunks'] == 1


### PR DESCRIPTION
## Summary
- add comprehensive tests for LLM status checks and payload handling
- extend OpenSearch utility tests covering partial failures, deletions, and flag updates

## Testing
- `pytest -q --cov --cov-branch --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_689cf3ac044c832a9c971d85d2fac2a7