### PR TITLE
Add smoke E2E test and failure capture

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import requests
 import pytest
+from playwright.sync_api import sync_playwright
 
 
 def _get_free_port() -> int:
@@ -41,3 +42,39 @@ def streamlit_app() -> str:
         proc.wait(timeout=5)
     except subprocess.TimeoutExpired:
         proc.kill()
+
+
+@pytest.fixture(scope="session")
+def browser():
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        yield browser
+        browser.close()
+
+
+@pytest.fixture
+def page(browser):
+    context = browser.new_context()
+    page = context.new_page()
+    page.console_logs = []
+    page.on("console", lambda msg: page.console_logs.append(f"{msg.type}: {msg.text}"))
+    yield page
+    context.close()
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    rep = outcome.get_result()
+    setattr(item, "rep_" + rep.when, rep)
+
+
+@pytest.fixture(autouse=True)
+def capture_artifacts(request, page):
+    yield
+    if request.node.rep_call.failed:
+        artifacts = Path("artifacts")
+        artifacts.mkdir(exist_ok=True)
+        page.screenshot(path=str(artifacts / f"{request.node.name}.png"))
+        log_file = artifacts / f"{request.node.name}.log"
+        log_file.write_text("\n".join(page.console_logs))

--- a/tests/e2e/test_smoke_e2e.py
+++ b/tests/e2e/test_smoke_e2e.py
@@ -1,0 +1,34 @@
+import pytest
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.e2e
+
+
+def test_smoke_e2e(streamlit_app, page):
+    """High-level smoke test covering primary UI flows."""
+    # Verify app loads and navigation updates heading
+    page.goto(streamlit_app)
+    expect(page.locator("h1")).to_contain_text("Talk to Your Documents")
+    page.get_by_role("link", name="Ingest").click()
+    expect(page.locator("h1")).to_contain_text("Ingest Documents")
+
+    # Ingest negative path: submit without file selection
+    page.get_by_role("button", name="Select File(s)").click()
+    expect(page.locator("div[role='alert']")).to_contain_text("select")
+
+    # Chat page: submit query and ensure answer rendered without console errors
+    page.get_by_role("link", name="Chat").click()
+    page.fill("textarea[placeholder='Ask a question...']", "What is Document QA?")
+    page.press("textarea[placeholder='Ask a question...']", "Enter")
+    page.wait_for_selector("div[data-testid='stChatMessage']")
+    assert not any("error" in m.lower() for m in page.console_logs)
+
+    # Index Viewer: table render, filter reduces rows, and CSV download control
+    page.get_by_role("link", name="Index Viewer").click()
+    page.wait_for_selector("table")
+    rows_before = page.locator("table tbody tr").count()
+    page.fill("input[aria-label='Filter by path substring']", "zzz")
+    page.wait_for_timeout(500)
+    rows_after = page.locator("table tbody tr").count()
+    assert rows_after <= rows_before
+    assert page.locator("button:has-text('Download')").is_visible()


### PR DESCRIPTION
## Summary
- add Playwright-based smoke test covering navigation, ingestion validation, chat, and index viewer
- capture screenshots and console logs on test failures

## Testing
- `pip install playwright pytest-playwright` (success)
- `playwright install chromium` (fails: Domain forbidden)
- `pytest tests/e2e/test_smoke_e2e.py -q` (fails: browser download 403)


------
https://chatgpt.com/codex/tasks/task_e_689da339f800832aa795ebc3ebba7891