### PR TITLE
Enable headless local E2E tests and streamline CI workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
       - name: 🐍 Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: |
             requirements/shared.txt
@@ -51,28 +51,6 @@ jobs:
 
       - name: 🌐 Install Playwright Chromium (with Linux deps)
         run: python -m playwright install --with-deps chromium
-
-      - name: 🚀 Launch Streamlit (headless) on :8501
-        env:
-          BROWSER: none
-        run: |
-          set -e
-          streamlit run main.py --server.headless true --server.port 8501 &
-          echo "🔍 Waiting for Streamlit to be ready..."
-          python -c "
-          import time, urllib.request, sys
-          url = 'http://localhost:8501'
-          for _ in range(90):
-              try:
-                  with urllib.request.urlopen(url, timeout=2) as r:
-                      if r.status == 200:
-                          print('✅ Streamlit is up')
-                          sys.exit(0)
-              except Exception:
-                  time.sleep(1)
-          print('❌ Streamlit did not start in time')
-          sys.exit(1)
-          "
 
       - name: 🧪 Run Playwright E2E tests
         run: pytest -q tests/e2e --maxfail=1 --disable-warnings

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    e2e: end-to-end tests.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,11 +1,14 @@
-import subprocess
-import time
+import os
 import socket
+import subprocess
+import sys
+import time
 from pathlib import Path
 
-import requests
 import pytest
+import requests
 from playwright.sync_api import sync_playwright
+from playwright._impl._errors import Error as PlaywrightError
 
 
 def _get_free_port() -> int:
@@ -16,13 +19,72 @@ def _get_free_port() -> int:
 
 @pytest.fixture(scope="session")
 def streamlit_app() -> str:
-    return "http://localhost:8501"
+    """Start the Streamlit app on a free port and yield its URL.
+
+    This allows running the E2E tests locally without having to manually
+    launch the application first. The server is terminated once the test
+    session finishes.
+    """
+
+    port = _get_free_port()
+    url = f"http://localhost:{port}"
+
+    env = os.environ.copy()
+    # Prevent Streamlit from opening a real browser window.
+    env.setdefault("BROWSER", "none")
+
+    proc = subprocess.Popen(
+        [
+            "streamlit",
+            "run",
+            "main.py",
+            "--server.headless",
+            "true",
+            "--server.port",
+            str(port),
+        ],
+        env=env,
+    )
+
+    # Wait for the server to become responsive.
+    for _ in range(90):
+        try:
+            r = requests.get(url, timeout=1)
+            if r.status_code == 200:
+                break
+        except Exception:
+            time.sleep(1)
+    else:
+        proc.kill()
+        raise RuntimeError("Streamlit did not start in time")
+
+    yield url
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
 
 
 @pytest.fixture(scope="session")
 def browser():
+    """Provide a headless Chromium browser for tests.
+
+    If the required browser binaries are missing (e.g. when running locally
+    without having executed ``playwright install``), they will be installed on
+    the fly.
+    """
     with sync_playwright() as p:
-        browser = p.chromium.launch()
+        try:
+            browser = p.chromium.launch(headless=True)
+        except PlaywrightError:
+            # Install missing browser binaries without attempting system package installs
+            subprocess.run(
+                [sys.executable, "-m", "playwright", "install", "chromium"],
+                check=True,
+            )
+            browser = p.chromium.launch(headless=True)
         yield browser
         browser.close()
 


### PR DESCRIPTION
## Summary
- start Streamlit automatically from E2E tests and auto-install Playwright browsers
- simplify E2E workflow to rely on tests for app startup
- register `e2e` pytest marker
- install Playwright browser binaries without Linux-specific dependencies for local runs
- use Python 3.11 in E2E workflow

## Testing
- `pytest tests/e2e -q`


------
https://chatgpt.com/codex/tasks/task_e_689dcde33288832a9c7dcccfbc1b3ad3