### PR TITLE
Add human‑readable file sizes across document index and logs

### DIFF
--- a/core/ingestion.py
+++ b/core/ingestion.py
@@ -23,6 +23,7 @@ from utils.file_utils import (
     hash_path,
     get_file_size,
     normalize_path,
+    format_file_size,
 )
 from utils import qdrant_utils
 from utils.opensearch_utils import (
@@ -85,10 +86,12 @@ def ingest_one(
         log.set(retry_of=retry_of)
     with log:
         checksum = compute_checksum(normalized_path)
+        size_bytes = get_file_size(normalized_path)
         log.set(
             checksum=checksum,
             path_hash=hash_path(normalized_path),
-            bytes=get_file_size(normalized_path),
+            bytes=size_bytes,
+            size=format_file_size(size_bytes),
         )
 
         # Skip if already indexed and unchanged (based on checksum + path)
@@ -163,6 +166,8 @@ def ingest_one(
         chunk["indexed_at"] = indexed_at
         chunk["created_at"] = created
         chunk["modified_at"] = modified
+        chunk["bytes"] = size_bytes
+        chunk["size"] = format_file_size(size_bytes)
         chunk["page"] = chunk.get("page", None)
         # position approx. (0..100)
         chunk["location_percent"] = round((i / max(len(chunks) - 1, 1)) * 100)

--- a/pages/3_duplicates_viewer.py
+++ b/pages/3_duplicates_viewer.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import streamlit as st
 from utils.opensearch_utils import get_duplicate_checksums, get_files_by_checksum
+from utils.file_utils import format_file_size
 
 st.set_page_config(page_title="Duplicate Files", page_icon="🗂️")
 
@@ -23,9 +24,10 @@ else:
                     "Modified": f.get("modified_at"),
                     "Indexed": f.get("indexed_at"),
                     "Chunks": f.get("num_chunks"),
+                    "Size": f.get("bytes", 0),
                 }
             )
     df = pd.DataFrame(rows)
-    st.dataframe(df, use_container_width=True)
+    st.dataframe(df.style.format({"Size": format_file_size}), use_container_width=True)
     csv = df.to_csv(index=False).encode("utf-8")
     st.download_button("Download CSV", csv, "duplicate_files.csv", "text/csv")

--- a/pages/4_ingest_logs.py
+++ b/pages/4_ingest_logs.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from core.ingestion import ingest
 from utils.opensearch_utils import search_ingest_logs
+from utils.file_utils import format_file_size
 
 st.set_page_config(page_title="Ingestion Logs", layout="wide")
 st.title("📝 Ingestion Logs")
@@ -35,6 +36,7 @@ if logs:
         [
             {
                 "Path": l.get("path"),
+                "Size": l.get("bytes", 0),
                 "Status": l.get("status"),
                 "Error": l.get("error_type"),
                 "Reason": (l.get("reason") or "")[:100],
@@ -46,7 +48,7 @@ if logs:
         ]
     )
     df_display = df.drop(columns=["log_id"])
-    st.dataframe(df_display, height=400)
+    st.dataframe(df_display.style.format({"Size": format_file_size}), height=400)
 
     # Only failed rows are eligible for reingest
     failed_df = df[df["Status"] == "failed"]

--- a/tests/test_ingest_logging.py
+++ b/tests/test_ingest_logging.py
@@ -25,4 +25,7 @@ def test_logs_emitted_for_up_to_date(monkeypatch, tmp_path):
     ingestion.ingest_one(str(file_path))
 
     assert client.docs, "expected a log document to be written"
-    assert client.docs[0]["status"] == "skipped_up_to_date"
+    doc = client.docs[0]
+    assert doc["status"] == "skipped_up_to_date"
+    assert doc["bytes"] == 5
+    assert doc["size"] == "5 B"

--- a/tests/test_opensearch_utils_extra.py
+++ b/tests/test_opensearch_utils_extra.py
@@ -33,8 +33,8 @@ class FakeClient:
         return {'deleted': len(q['bool']['should'])}
     def search(self, index, body):
         return {'hits': {'hits': [
-            {'_id': '1', '_score': 1.0, '_source': {'path': 'p', 'checksum': 'c', 'text': 't', 'chunk_index':0, 'modified_at':'2020'}},
-            {'_id': '2', '_score': 0.5, '_source': {'path': 'p2', 'checksum': 'c2', 'text': 't2', 'chunk_index':1, 'modified_at':'2019'}},
+            {'_id': '1', '_score': 1.0, '_source': {'path': 'p', 'checksum': 'c', 'text': 't', 'chunk_index':0, 'modified_at':'2020', 'bytes': 123, 'size': '123 B'}},
+            {'_id': '2', '_score': 0.5, '_source': {'path': 'p2', 'checksum': 'c2', 'text': 't2', 'chunk_index':1, 'modified_at':'2019', 'bytes': 456, 'size': '456 B'}},
         ]}}
 
 
@@ -90,3 +90,4 @@ def test_get_files_by_checksum(monkeypatch):
     files = osu.get_files_by_checksum('c')
     assert files[0]['path'] == 'p'
     assert files[0]['num_chunks'] == 1
+    assert files[0]['bytes'] == 123

--- a/tests/test_opensearch_utils_remaining.py
+++ b/tests/test_opensearch_utils_remaining.py
@@ -60,6 +60,8 @@ def test_list_files_from_opensearch(monkeypatch):
                                                     "modified_at": 2,
                                                     "indexed_at": 3,
                                                     "filetype": "txt",
+                                                    "bytes": 100,
+                                                    "size": "100 B",
                                                 },
                                             }
                                         ]
@@ -80,6 +82,8 @@ def test_list_files_from_opensearch(monkeypatch):
                                                     "modified_at": 5,
                                                     "indexed_at": 6,
                                                     "filetype": "pdf",
+                                                    "bytes": 200,
+                                                    "size": "200 B",
                                                 },
                                             }
                                         ]
@@ -96,6 +100,8 @@ def test_list_files_from_opensearch(monkeypatch):
     assert files[0]["num_chunks"] == 2
     assert files[1]["filename"] == "file2.pdf"
     assert files[1]["first_chunk_id"] == "2"
+    assert files[0]["bytes"] == 100
+    assert files[1]["size"] == "200 B"
 
 
 def test_get_duplicate_checksums_with_fallback(monkeypatch):

--- a/tests/ui_apptest/test_duplicates_apptest.py
+++ b/tests/ui_apptest/test_duplicates_apptest.py
@@ -10,6 +10,7 @@ def test_duplicate_table_renders(monkeypatch):
         "modified_at": "1",
         "indexed_at": "1",
         "num_chunks": 1,
+        "bytes": 100,
     }
     files = {
         "c1": [
@@ -37,3 +38,4 @@ def test_duplicate_table_renders(monkeypatch):
     df = at.dataframe[0].value
     assert len(df) == 3
     assert df["Checksum"].value_counts().to_dict() == {"c1": 2, "c2": 1}
+    assert "Size" in df.columns

--- a/tests/ui_apptest/test_index_viewer_apptest.py
+++ b/tests/ui_apptest/test_index_viewer_apptest.py
@@ -1,0 +1,29 @@
+from streamlit.testing.v1 import AppTest
+
+
+def test_index_viewer_shows_size(monkeypatch):
+    files = [
+        {
+            "filename": "a.txt",
+            "path": "/a.txt",
+            "filetype": "txt",
+            "modified_at": "1",
+            "created_at": "1",
+            "indexed_at": "1",
+            "num_chunks": 1,
+            "qdrant_count": 0,
+            "first_chunk_id": "1",
+            "checksum": "c1",
+            "bytes": 1024,
+        }
+    ]
+    monkeypatch.setattr(
+        "utils.opensearch_utils.list_files_from_opensearch", lambda: files
+    )
+
+    at = AppTest.from_file("pages/2_index_viewer.py", default_timeout=10)
+    at.run()
+
+    df = at.dataframe[0].value
+    assert "Size" in df.columns
+    assert df["Size"].iloc[0] == 1024

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -8,6 +8,7 @@ __all__ = [
     "hash_path",
     "get_file_size",
     "get_file_timestamps",
+    "format_file_size",
 ]
 
 
@@ -38,6 +39,28 @@ def get_file_size(path: str) -> int:
         return os.path.getsize(path)
     except OSError:
         return 0
+
+
+def format_file_size(num_bytes: int) -> str:
+    """Return a human-friendly string for a byte size.
+
+    Uses binary multiples (KB, MB, GB, ...) and keeps one decimal place for
+    non-integer values. Falls back to ``0 B`` for invalid inputs.
+    """
+    try:
+        size = float(num_bytes)
+    except (TypeError, ValueError):
+        return "0 B"
+
+    units = ["B", "KB", "MB", "GB", "TB", "PB"]
+    idx = 0
+    while size >= 1024 and idx < len(units) - 1:
+        size /= 1024
+        idx += 1
+    if units[idx] == "B":
+        return f"{int(size)} {units[idx]}"
+    else:
+        return f"{size:.1f} {units[idx]}"
 
 
 def get_file_timestamps(path: str) -> dict:

--- a/utils/opensearch_utils.py
+++ b/utils/opensearch_utils.py
@@ -36,6 +36,8 @@ INDEX_SETTINGS = {
             "indexed_at": {"type": "date"},
             "created_at": {"type": "date"},
             "modified_at": {"type": "date"},
+            "bytes": {"type": "long"},
+            "size": {"type": "keyword"},
             "page": {"type": "integer"},
             "location_percent": {"type": "float"},
         }
@@ -60,6 +62,7 @@ INGEST_LOGS_SETTINGS = {
             "attempt_at": {"type": "date"},
             "duration_ms": {"type": "long"},
             "bytes": {"type": "long"},
+            "size": {"type": "keyword"},
             "user": {"type": "keyword"},
             "host": {"type": "keyword"},
             "retry_of": {"type": "keyword"},
@@ -139,6 +142,8 @@ def list_files_from_opensearch(
                                     "modified_at",
                                     "indexed_at",
                                     "filetype",
+                                    "bytes",
+                                    "size",
                                 ],
                                 "sort": [{"indexed_at": "desc"}],
                             }
@@ -166,6 +171,8 @@ def list_files_from_opensearch(
                 "modified_at": top_source.get("modified_at"),
                 "indexed_at": top_source.get("indexed_at"),
                 "filetype": top_source.get("filetype"),
+                "bytes": top_source.get("bytes"),
+                "size": top_source.get("size"),
                 "num_chunks": doc_count,
                 "first_chunk_id": top_chunk_id,
             }
@@ -349,6 +356,8 @@ def get_files_by_checksum(checksum: str) -> List[Dict[str, Any]]:
                 "created_at": src.get("created_at"),
                 "modified_at": src.get("modified_at"),
                 "indexed_at": src.get("indexed_at"),
+                "bytes": src.get("bytes"),
+                "size": src.get("size"),
                 "checksum": checksum,
                 "num_chunks": 0,
             },


### PR DESCRIPTION
## Summary
- record raw bytes and human-friendly size for each chunk in OpenSearch
- surface file size in file index viewer and duplicate files pages
- test index viewer displays size column

## Testing
- `pytest tests/test_ingest_logging.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f5899a6c4832aa2479102cf561270