### PR TITLE
feat: add context menu to index viewer

### DIFF
--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -9,3 +9,4 @@ langchain-text-splitters==0.3.*
 pypdf>=5,<6
 docx2txt>=0.9,<1.0
 ftfy
+streamlit-aggrid>=1.1,<2

--- a/utils/opensearch_utils.py
+++ b/utils/opensearch_utils.py
@@ -176,6 +176,17 @@ def list_files_from_opensearch(
     return results
 
 
+def get_chunks_by_path(path: str) -> List[Dict[str, Any]]:
+    """Return all chunk documents for a given file path."""
+    client = get_client()
+    resp = client.search(
+        index=OPENSEARCH_INDEX,
+        body={"size": 10000, "query": {"term": {"path.keyword": path}}},
+    )
+    hits = resp.get("hits", {}).get("hits", [])
+    return [{"id": h.get("_id"), **h.get("_source", {})} for h in hits]
+
+
 def delete_files_by_checksum(checksums: Iterable[str]) -> int:
     """Delete all OpenSearch docs that match any of the given checksums.
     Uses batched `terms` delete_by_query for speed. Returns total deleted count.


### PR DESCRIPTION
## Summary
- show indexed file table with AgGrid and per-row context menu actions
- support file open, folder open, reingest, sync embeddings, delete via new handlers
- add OpenSearch helper to fetch chunks by path and include streamlit-aggrid dependency

## Testing
- `pip install -r requirements/app.txt`
- `pip install -r requirements/dev.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fb4653620832a90aece530f511d0c