### PR TITLE
feat: switch OpenSearch to parent-child join

### DIFF
--- a/config.py
+++ b/config.py
@@ -68,6 +68,12 @@ INGEST_LOG_INDEX_BASE  = _env_str("INGEST_LOG_INDEX_BASE", "ingest_logs")
 OPENSEARCH_INDEX       = _namespaced(OPENSEARCH_INDEX_BASE)
 INGEST_LOG_INDEX       = _namespaced(INGEST_LOG_INDEX_BASE)
 
+# ── Parent/child retrieval tuning
+OS_MIN_CHILDREN = _env_int("OS_MIN_CHILDREN", 1)
+OS_INNER_HITS = _env_int("OS_INNER_HITS", 3)
+HYBRID_W_OS = float(_env_str("HYBRID_W_OS", "0.6"))
+HYBRID_W_VEC = float(_env_str("HYBRID_W_VEC", "0.4"))
+
 # ── LLM API (text-generation-webui compatible)
 LLM_BASE_URL            = _env_str("LLM_BASE_URL", "http://localhost:5000").rstrip("/")
 LLM_GENERATE_ENDPOINT   = _env_str("LLM_GENERATE_ENDPOINT",   f"{LLM_BASE_URL}/api/v1/generate")

--- a/core/ingestion.py
+++ b/core/ingestion.py
@@ -151,16 +151,20 @@ def ingest_one(
         logger.info(f"🧩 Split into {len(chunks)} chunks")
 
     # Build per-chunk metadata; UUIDv5 id uses path+chunk index so duplicates across paths get unique ids
+    doc_id = str(uuid.uuid5(uuid.NAMESPACE_URL, normalized_path))
+    filename = os.path.basename(normalized_path)
     for i, chunk in enumerate(chunks):
         chunk["id"] = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{normalized_path}-{i}"))
         chunk["chunk_index"] = i
         chunk["path"] = normalized_path
+        chunk["filename"] = filename
+        chunk["doc_id"] = doc_id
         chunk["checksum"] = checksum
         chunk["filetype"] = ext
         chunk["indexed_at"] = indexed_at
         chunk["created_at"] = created
         chunk["modified_at"] = modified
-        chunk["bytes"] = size_bytes
+        chunk["size_bytes"] = size_bytes
         chunk["size"] = format_file_size(size_bytes)
         chunk["page"] = chunk.get("page", None)
         # position approx. (0..100)

--- a/scripts/ingest_sample.py
+++ b/scripts/ingest_sample.py
@@ -1,0 +1,19 @@
+"""Ingest a small folder of documents for smoke testing."""
+
+import os
+import sys
+
+from core.ingestion import ingest_one
+
+
+def ingest_folder(folder: str) -> None:
+    for root, _dirs, files in os.walk(folder):
+        for name in files:
+            path = os.path.join(root, name)
+            ingest_one(path)
+
+
+if __name__ == "__main__":
+    folder = sys.argv[1] if len(sys.argv) > 1 else "assets/sample_docs"
+    ingest_folder(folder)
+

--- a/scripts/os_recreate_join_index.py
+++ b/scripts/os_recreate_join_index.py
@@ -1,0 +1,20 @@
+"""Recreate the OpenSearch index with parent/child join mapping."""
+
+from utils.opensearch_utils import INDEX_SETTINGS
+from core.opensearch_client import get_client
+from config import OPENSEARCH_INDEX, logger
+
+
+def recreate() -> None:
+    client = get_client()
+    if client.indices.exists(index=OPENSEARCH_INDEX):
+        logger.info(f"Deleting existing index {OPENSEARCH_INDEX}")
+        client.indices.delete(index=OPENSEARCH_INDEX)
+
+    logger.info(f"Creating index {OPENSEARCH_INDEX} with join mapping")
+    client.indices.create(index=OPENSEARCH_INDEX, body=INDEX_SETTINGS)
+
+
+if __name__ == "__main__":
+    recreate()
+

--- a/tests/test_opensearch_utils_extra.py
+++ b/tests/test_opensearch_utils_extra.py
@@ -49,11 +49,11 @@ def test_ensure_index_noop(monkeypatch):
 def test_bulk_index_partial_failure(monkeypatch, caplog):
     client = FakeClient()
     monkeypatch.setattr(osu, 'get_client', lambda: client)
-    def fake_bulk(client, actions):
+    def fake_bulk(client, actions, **kw):
         return (1, ['err'])
     monkeypatch.setattr(osu, 'helpers', types.SimpleNamespace(bulk=fake_bulk))
     caplog.set_level(logging.ERROR)
-    osu.index_documents([{ 'id':'1','text':'a'}])
+    osu.index_documents([{ 'id':'1','text':'a','doc_id':'d','filename':'f','path':'p'}])
     assert any('OpenSearch indexing failed' in r.message for r in caplog.records)
 
 

--- a/tests/test_search_dedup.py
+++ b/tests/test_search_dedup.py
@@ -10,9 +10,48 @@ def test_search_deduplicates_by_checksum(monkeypatch):
             return {
                 "hits": {
                     "hits": [
-                        {"_id": "1", "_score": 1.0, "_source": {"path": "a", "text": "t1", "chunk_index": 0, "modified_at": "", "checksum": "abc"}},
-                        {"_id": "2", "_score": 0.9, "_source": {"path": "b", "text": "t1", "chunk_index": 0, "modified_at": "", "checksum": "abc"}},
-                        {"_id": "3", "_score": 0.8, "_source": {"path": "c", "text": "t2", "chunk_index": 0, "modified_at": "", "checksum": "def"}},
+                        {
+                            "_id": "p1",
+                            "_score": 1.0,
+                            "_source": {"path": "a", "doc_id": "d1", "checksum": "abc"},
+                            "inner_hits": {
+                                "chunk": {
+                                    "hits": {
+                                        "hits": [
+                                            {"_source": {"text": "t1", "chunk_index": 0}}
+                                        ]
+                                    }
+                                }
+                            },
+                        },
+                        {
+                            "_id": "p2",
+                            "_score": 0.9,
+                            "_source": {"path": "b", "doc_id": "d2", "checksum": "abc"},
+                            "inner_hits": {
+                                "chunk": {
+                                    "hits": {
+                                        "hits": [
+                                            {"_source": {"text": "t1", "chunk_index": 0}}
+                                        ]
+                                    }
+                                }
+                            },
+                        },
+                        {
+                            "_id": "p3",
+                            "_score": 0.8,
+                            "_source": {"path": "c", "doc_id": "d3", "checksum": "def"},
+                            "inner_hits": {
+                                "chunk": {
+                                    "hits": {
+                                        "hits": [
+                                            {"_source": {"text": "t2", "chunk_index": 0}}
+                                        ]
+                                    }
+                                }
+                            },
+                        },
                     ]
                 }
             }


### PR DESCRIPTION
## Summary
- replace flat OpenSearch chunks with parent→child join mapping
- surface document hits via `has_child` with inner hits for snippet evidence
- add scripts for join index creation and sample ingestion, and fuse hybrid scores at doc level

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a229fec81c832a8125abaeee12191d