### PR TITLE
Adapt tests to updated OpenSearch client

### DIFF
--- a/tests/test_opensearch_utils.py
+++ b/tests/test_opensearch_utils.py
@@ -46,7 +46,7 @@ def test_ensure_index_exists_creates_mapping(monkeypatch):
         def exists(self, index):
             return False
 
-        def create(self, index, body):
+        def create(self, index, body, params=None):
             created["index"] = index
             created["body"] = body
 

--- a/tests/test_opensearch_utils_extra.py
+++ b/tests/test_opensearch_utils_extra.py
@@ -8,7 +8,7 @@ class FakeIndices:
         self.created = []
     def exists(self, index):
         return self.exists_flag
-    def create(self, index, body):
+    def create(self, index, body, params=None):
         self.created.append((index, body))
 
 class FakeClient:

--- a/tests/test_opensearch_utils_remaining.py
+++ b/tests/test_opensearch_utils_remaining.py
@@ -28,7 +28,7 @@ def test_ensure_ingest_log_index_exists(monkeypatch):
             self.exists_called_with = index
             return False
 
-        def create(self, index, body):
+        def create(self, index, body, params=None):
             self.create_called_with.append((index, body))
 
     class FakeClient:

--- a/tests/ui_apptest/test_index_viewer_apptest.py
+++ b/tests/ui_apptest/test_index_viewer_apptest.py
@@ -1,3 +1,16 @@
+import sys
+import types
+
+# provide a minimal opensearchpy stub so streamlit pages can be imported
+opensearchpy_stub = types.ModuleType("opensearchpy")
+opensearchpy_stub.exceptions = types.ModuleType("exceptions")
+opensearchpy_stub.exceptions.NotFoundError = Exception
+opensearchpy_stub.exceptions.TransportError = Exception
+opensearchpy_stub.OpenSearch = object
+opensearchpy_stub.helpers = types.SimpleNamespace()
+sys.modules.setdefault("opensearchpy", opensearchpy_stub)
+sys.modules.setdefault("opensearchpy.exceptions", opensearchpy_stub.exceptions)
+
 from streamlit.testing.v1 import AppTest
 
 

--- a/tests/ui_apptest/test_nav_apptest.py
+++ b/tests/ui_apptest/test_nav_apptest.py
@@ -1,7 +1,20 @@
 import re
 from pathlib import Path
+import sys
+import types
 
 import pytest
+
+# provide a minimal opensearchpy stub so streamlit pages can be imported
+opensearchpy_stub = types.ModuleType("opensearchpy")
+opensearchpy_stub.exceptions = types.ModuleType("exceptions")
+opensearchpy_stub.exceptions.NotFoundError = Exception
+opensearchpy_stub.exceptions.TransportError = Exception
+opensearchpy_stub.OpenSearch = object
+opensearchpy_stub.helpers = types.SimpleNamespace()
+sys.modules.setdefault("opensearchpy", opensearchpy_stub)
+sys.modules.setdefault("opensearchpy.exceptions", opensearchpy_stub.exceptions)
+
 from streamlit.testing.v1 import AppTest
 
 # Mapping of page script to expected title text and navigation label


### PR DESCRIPTION
## Summary
- Update OpenSearch test stubs to accept new `params` argument in index creation helpers
- Stub `opensearchpy` module in Streamlit AppTests to avoid missing dependency errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a609c3fc64832a9e59d0bcf5baa5d2