### PR TITLE
Use local timezone for ingestion timestamps

### DIFF
--- a/core/ingestion.py
+++ b/core/ingestion.py
@@ -3,7 +3,7 @@ import uuid
 import time
 import threading
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import List, Dict, Any, Callable, Optional, Iterable, Union
 from core.document_preprocessor import preprocess_to_documents, PreprocessConfig
 from core.file_loader import load_documents
@@ -107,7 +107,8 @@ def ingest_one(
         timestamps = get_file_timestamps(normalized_path)
         created = timestamps.get("created")
         modified = timestamps.get("modified")
-        indexed_at = datetime.now(timezone.utc).isoformat()
+        # Use local timezone for indexing timestamp
+        indexed_at = datetime.now().astimezone().isoformat()
 
         logger.info(f"📄 Loading: {normalized_path}")
         try:

--- a/pages/5_search.py
+++ b/pages/5_search.py
@@ -1,6 +1,6 @@
 import streamlit as st
 import math
-from datetime import date, time, datetime, timezone
+from datetime import date, time, datetime, tzinfo
 from utils.file_utils import format_file_size, open_file_local
 from utils.time_utils import format_timestamp, format_date
 from utils.fulltext_search import search_documents
@@ -33,12 +33,20 @@ for k, v in _defaults.items():
     st.session_state.setdefault(k, v)
 
 
+def _local_tz() -> tzinfo:
+    return datetime.now().astimezone().tzinfo  # type: ignore[return-value]
+
+
 def _iso_start(d: date | None) -> str | None:
-    return datetime.combine(d, time.min, tzinfo=timezone.utc).isoformat() if d else None
+    return (
+        datetime.combine(d, time.min, tzinfo=_local_tz()).isoformat() if d else None
+    )
 
 
 def _iso_end(d: date | None) -> str | None:
-    return datetime.combine(d, time.max, tzinfo=timezone.utc).isoformat() if d else None
+    return (
+        datetime.combine(d, time.max, tzinfo=_local_tz()).isoformat() if d else None
+    )
 
 
 def current_params() -> dict | None:

--- a/scripts/seed_test_backends.py
+++ b/scripts/seed_test_backends.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 from opensearchpy import OpenSearch, helpers
 from qdrant_client import QdrantClient, models
 from config import (
@@ -36,8 +36,8 @@ docs = [
     {"_index": OPENSEARCH_INDEX, "_id": "2", "_op_type": "create",
      "_source": {"text":"Another sentence mentioning a city.",
                  "path":"C:/docs/doc2.txt",
-                 "modified_at": datetime.now(timezone.utc).isoformat(),
-                 "indexed_at":  datetime.now(timezone.utc).isoformat(),
+                 "modified_at": datetime.now().astimezone().isoformat(),
+                 "indexed_at":  datetime.now().astimezone().isoformat(),
                  "checksum":"chk-2","chunk_index":0}}
 ]
 helpers.bulk(os_client, docs)
@@ -56,6 +56,6 @@ points = [
                  "page":1,"checksum":"chk-1","chunk_index":0,"modified_at":"2024-01-01T00:00:00Z"}),
     models.PointStruct(id=2, vector=vec,
         payload={"path":"C:/docs/doc2.txt","text":"Another sentence mentioning a city.",
-                 "page":1,"checksum":"chk-2","chunk_index":0,"modified_at": datetime.now(timezone.utc).isoformat()}),
+                 "page":1,"checksum":"chk-2","chunk_index":0,"modified_at": datetime.now().astimezone().isoformat()}),
 ]
 qd.upsert(collection_name=QDRANT_COLLECTION, points=points)

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -87,8 +87,12 @@ def get_file_timestamps(path: str) -> dict:
     else:
         modified_dt = datetime.fromtimestamp(st.st_mtime, tz=timezone.utc)
 
+    # Convert to local timezone for consistency with user-facing logs
+    modified_dt = modified_dt.astimezone()
     created_dt = (
-        datetime.fromtimestamp(created_ts, tz=timezone.utc) if created_ts is not None else None
+        datetime.fromtimestamp(created_ts, tz=timezone.utc).astimezone()
+        if created_ts is not None
+        else None
     )
 
     return {"created": created_dt, "modified": modified_dt}

--- a/utils/ingest_logging.py
+++ b/utils/ingest_logging.py
@@ -1,6 +1,5 @@
 import time
-import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 from config import logger, INGEST_LOG_INDEX
@@ -32,7 +31,8 @@ class IngestLogEmitter:
 
     def __enter__(self) -> "IngestLogEmitter":
         self._start = time.time()
-        self.doc["attempt_at"] = datetime.now(timezone.utc).isoformat()
+        # Record attempt time in the local timezone
+        self.doc["attempt_at"] = datetime.now().astimezone().isoformat()
         try:
             ensure_ingest_log_index_exists()
         except Exception as e:  # best effort


### PR DESCRIPTION
## Summary
- record ingestion start and attempt timestamps using the host's local timezone
- convert file creation/modification metadata to local timezone
- adjust search filters and seed script to emit local-timezone dates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a86c0eb9d0832a8cc7eb308dd9e99c