### PR TITLE
Display modified and created times in 12-hour format

### DIFF
--- a/pages/2_index_viewer.py
+++ b/pages/2_index_viewer.py
@@ -7,7 +7,7 @@ from utils.file_utils import open_file_local, show_in_folder
 from opensearchpy.exceptions import NotFoundError, TransportError
 from typing import List, Dict, Any
 
-from utils.time_utils import format_timestamp
+from utils.time_utils import format_timestamp, format_timestamp_ampm
 from utils.opensearch_utils import (
     list_files_from_opensearch,
     delete_files_by_path_checksum,
@@ -78,8 +78,8 @@ def build_table_data(files: List[Dict[str, Any]]) -> pd.DataFrame:
                 "Filename": f.get("filename", ""),
                 "Path": f.get("path", ""),
                 "Filetype": f.get("filetype", ""),
-                "Modified": format_timestamp(f.get("modified_at") or ""),
-                "Created": format_timestamp(f.get("created_at") or ""),
+                "Modified": format_timestamp_ampm(f.get("modified_at") or ""),
+                "Created": format_timestamp_ampm(f.get("created_at") or ""),
                 "Indexed": format_timestamp(f.get("indexed_at") or ""),
                 "Size": f.get("bytes", 0),
                 "OpenSearch Chunks": f.get("num_chunks", 0),

--- a/pages/3_duplicates_viewer.py
+++ b/pages/3_duplicates_viewer.py
@@ -2,6 +2,7 @@ import pandas as pd
 import streamlit as st
 from utils.opensearch_utils import get_duplicate_checksums, get_files_by_checksum
 from utils.file_utils import format_file_size
+from utils.time_utils import format_timestamp, format_timestamp_ampm
 
 st.set_page_config(page_title="Duplicate Files", page_icon="🗂️")
 
@@ -20,9 +21,9 @@ else:
                     "Checksum": checksum,
                     "Path": f.get("path"),
                     "Filetype": f.get("filetype"),
-                    "Created": f.get("created_at"),
-                    "Modified": f.get("modified_at"),
-                    "Indexed": f.get("indexed_at"),
+                    "Created": format_timestamp_ampm(f.get("created_at") or ""),
+                    "Modified": format_timestamp_ampm(f.get("modified_at") or ""),
+                    "Indexed": format_timestamp(f.get("indexed_at") or ""),
                     "Chunks": f.get("num_chunks"),
                     "Size": f.get("bytes", 0),
                 }

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -2,12 +2,26 @@ from datetime import datetime
 
 
 def format_timestamp(ts: str, fmt: str = "%Y-%m-%d %H:%M:%S") -> str:
-    """
-    Convert ISO timestamp to a clean human-readable format.
+    """Convert ISO timestamp to a human-readable format.
+
     If invalid or missing, return 'N/A'.
     """
     try:
         return datetime.fromisoformat(ts).strftime(fmt)
+    except Exception:
+        return "N/A"
+
+
+def format_timestamp_ampm(ts: str) -> str:
+    """Return timestamp as 'YYYY-MM-DD H:MM AM/PM'.
+
+    The hour omits any leading zero and seconds are discarded. Returns 'N/A'
+    if parsing fails.
+    """
+    try:
+        dt = datetime.fromisoformat(ts)
+        time_part = dt.strftime("%I:%M %p").lstrip("0")
+        return f"{dt.strftime('%Y-%m-%d')} {time_part}"
     except Exception:
         return "N/A"
 
@@ -21,3 +35,4 @@ def format_date(ts: str, fmt: str = "%d %B %Y") -> str:
         return datetime.fromisoformat(ts).strftime(fmt)
     except Exception:
         return str(ts)[:10]  # last resort
+


### PR DESCRIPTION
## Summary
- Add helper to format timestamps as `YYYY-MM-DD H:MM AM/PM`
- Show created and modified times in index and duplicates viewers using the new format
- Leave ingestion and attempt times in 24-hour format with seconds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a871ba05a4832ab2327d20c83035fd