### PR TITLE
Apply global sorting across paginated index tables

### DIFF
--- a/pages/2_index_viewer.py
+++ b/pages/2_index_viewer.py
@@ -95,7 +95,15 @@ def build_table_data(files: List[Dict[str, Any]]) -> pd.DataFrame:
             }
         )
     df = pd.DataFrame(rows)
-    if "Modified" in df.columns:
+    sort_state = st.session_state.get("index_sort_by")
+    if sort_state:
+        sort_col, sort_asc = sort_state
+        if sort_col in df.columns:
+            try:
+                df = df.sort_values(sort_col, ascending=sort_asc, kind="mergesort")
+            except Exception:
+                pass
+    elif "Modified" in df.columns:
         df = df.sort_values("Modified", ascending=False, na_position="last")
     return df.reset_index(drop=True)
 

--- a/pages/2_index_viewer.py
+++ b/pages/2_index_viewer.py
@@ -98,9 +98,19 @@ def build_table_data(files: List[Dict[str, Any]]) -> pd.DataFrame:
     sort_state = st.session_state.get("index_sort_by")
     if sort_state:
         sort_col, sort_asc = sort_state
-        if sort_col in df.columns:
+        # Map the stored column identifier to an actual column name.
+        sort_key = None
+        if isinstance(sort_col, int):
+            if 0 <= sort_col < len(df.columns):
+                sort_key = df.columns[sort_col]
+        else:
+            sort_key = next(
+                (c for c in df.columns if c.lower() == str(sort_col).lower()),
+                None,
+            )
+        if sort_key:
             try:
-                df = df.sort_values(sort_col, ascending=sort_asc, kind="mergesort")
+                df = df.sort_values(sort_key, ascending=sort_asc, kind="mergesort")
             except Exception:
                 pass
     elif "Modified" in df.columns:


### PR DESCRIPTION
## Summary
- Apply server-side column sorting to all filtered rows before pagination so sorting affects the entire dataset.
- Persist user-selected sort order from `st.dataframe` events and rerun to maintain consistent paging.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8e754704c832aa9dbcbce83f05319