### PR TITLE
Align tests with ingestion's Document-based API

### DIFF
--- a/tests/test_ingestion_extra.py
+++ b/tests/test_ingestion_extra.py
@@ -2,6 +2,7 @@ import os
 import types
 
 import pytest
+from langchain_core.documents import Document
 
 from core.ingestion import ingest_one
 
@@ -59,7 +60,10 @@ def test_ingest_one_embedder_failure(tmp_path, monkeypatch):
     monkeypatch.setattr("core.ingestion.is_duplicate_checksum", lambda c, p: False)
     monkeypatch.setattr("core.ingestion.IngestLogEmitter", DummyLog)
 
-    monkeypatch.setattr("core.ingestion.load_documents", lambda p: ["doc"])  # one doc
+    monkeypatch.setattr(
+        "core.ingestion.load_documents",
+        lambda p: [Document(page_content="doc", metadata={})],
+    )  # one doc
     monkeypatch.setattr(
         "core.ingestion.preprocess_to_documents",
         lambda docs_like, source_path, cfg, doc_type: docs_like,
@@ -94,7 +98,10 @@ def test_ingest_one_batching(tmp_path, monkeypatch):
     monkeypatch.setattr("core.ingestion.is_duplicate_checksum", lambda c, p: False)
     monkeypatch.setattr("core.ingestion.IngestLogEmitter", DummyLog)
 
-    monkeypatch.setattr("core.ingestion.load_documents", lambda p: ["doc"])  # one doc
+    monkeypatch.setattr(
+        "core.ingestion.load_documents",
+        lambda p: [Document(page_content="doc", metadata={})],
+    )  # one doc
     monkeypatch.setattr(
         "core.ingestion.preprocess_to_documents",
         lambda docs_like, source_path, cfg, doc_type: docs_like,
@@ -131,7 +138,10 @@ def test_ingest_one_background_many_files(tmp_path, monkeypatch):
     monkeypatch.setattr("core.ingestion.is_duplicate_checksum", lambda c, p: False)
     monkeypatch.setattr("core.ingestion.IngestLogEmitter", DummyLog)
 
-    monkeypatch.setattr("core.ingestion.load_documents", lambda p: ["doc"])  # one doc
+    monkeypatch.setattr(
+        "core.ingestion.load_documents",
+        lambda p: [Document(page_content="doc", metadata={})],
+    )  # one doc
     monkeypatch.setattr(
         "core.ingestion.preprocess_to_documents",
         lambda docs_like, source_path, cfg, doc_type: docs_like,

--- a/tests/ui_apptest/test_ingest_apptest.py
+++ b/tests/ui_apptest/test_ingest_apptest.py
@@ -68,7 +68,7 @@ def test_ingest_success_and_progress(monkeypatch):
 
     # Success notice and log row
     assert "Found 1 path" in at.success[0].value
-    assert "Queued" in at.success[1].value
+    assert "Indexed" in at.success[1].value
     assert len(at.dataframe[0].value) == 1
 
     # Progress callback invoked for 0 -> 50 -> 100%


### PR DESCRIPTION
## Summary
- replace string stubs with `Document` objects in ingestion tests
- update ingest UI test to expect direct indexing message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9c70e2f9c832a9f1ecdf48dab5590