### PR TITLE
Align indexing helpers with full-text error handling

### DIFF
--- a/core/ingestion.py
+++ b/core/ingestion.py
@@ -227,12 +227,13 @@ def ingest_one(
         # SMALL workload → do EVERYTHING locally
         try:
             logger.info(f"Indexing {len(chunks)} chunks to OpenSearch (small file).")
-            index_documents(chunks)
+            try:
+                index_documents(chunks)
+            except Exception as e:
+                logger.warning(f"OpenSearch chunk indexing failed: {e}")
 
             logger.info(f"Embedding + upserting {len(chunks)} chunks locally.")
-            ok = qdrant_utils.index_chunks(chunks)  # embeds + upserts
-            if not ok:
-                raise RuntimeError("Qdrant upsert returned falsy")
+            qdrant_utils.index_chunks(chunks)  # embeds + upserts
 
             ids = [c["id"] for c in chunks]
             updated, _errs = set_has_embedding_true_by_ids(ids)

--- a/core/ingestion_tasks.py
+++ b/core/ingestion_tasks.py
@@ -36,7 +36,10 @@ def index_and_embed_chunks(self, chunks: List[Dict[str, Any]]) -> Dict[str, Any]
     total = len(chunks)
     try:
         # 1) Index to OpenSearch
-        index_documents(chunks)
+        try:
+            index_documents(chunks)
+        except Exception as e:
+            logger.warning("OpenSearch chunk indexing failed: %s", e)
         self.update_state(
             state="PROGRESS",
             meta={
@@ -48,9 +51,7 @@ def index_and_embed_chunks(self, chunks: List[Dict[str, Any]]) -> Dict[str, Any]
         )
 
         # 2) Embed + upsert to Qdrant
-        ok = qdrant_utils.index_chunks(chunks)
-        if not ok:
-            raise RuntimeError("Qdrant upsert failed for batch")
+        qdrant_utils.index_chunks(chunks)
         self.update_state(
             state="PROGRESS",
             meta={

--- a/core/reembed.py
+++ b/core/reembed.py
@@ -23,9 +23,7 @@ def reembed_paths(paths: List[str]) -> int:
         logger.info("No chunks found for re-embedding.")
         return 0
 
-    ok = qdrant_utils.index_chunks(chunks)
-    if not ok:
-        raise RuntimeError("Qdrant indexing failed")
+    qdrant_utils.index_chunks(chunks)
 
     ids = [c.get("id") for c in chunks if c.get("id")]
     if ids:

--- a/tests/test_ingestion_extra.py
+++ b/tests/test_ingestion_extra.py
@@ -2,6 +2,7 @@ import os
 import types
 
 import pytest
+from langchain_core.documents import Document
 
 from core.ingestion import ingest_one
 
@@ -59,7 +60,9 @@ def test_ingest_one_embedder_failure(tmp_path, monkeypatch):
     monkeypatch.setattr("core.ingestion.is_duplicate_checksum", lambda c, p: False)
     monkeypatch.setattr("core.ingestion.IngestLogEmitter", DummyLog)
 
-    monkeypatch.setattr("core.ingestion.load_documents", lambda p: ["doc"])  # one doc
+    monkeypatch.setattr(
+        "core.ingestion.load_documents", lambda p: [Document(page_content="hello")]
+    )  # one doc
     monkeypatch.setattr(
         "core.ingestion.preprocess_to_documents",
         lambda docs_like, source_path, cfg, doc_type: docs_like,
@@ -67,7 +70,10 @@ def test_ingest_one_embedder_failure(tmp_path, monkeypatch):
     monkeypatch.setattr("core.ingestion.split_documents", lambda docs: [{"text": "hello"}])
     monkeypatch.setattr("core.ingestion.index_documents", lambda chunks: None)
 
-    monkeypatch.setattr("utils.qdrant_utils.index_chunks", lambda chunks: False)
+    def fail_index(_chunks):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr("utils.qdrant_utils.index_chunks", fail_index)
 
     called = {"flip": False}
 
@@ -94,7 +100,9 @@ def test_ingest_one_batching(tmp_path, monkeypatch):
     monkeypatch.setattr("core.ingestion.is_duplicate_checksum", lambda c, p: False)
     monkeypatch.setattr("core.ingestion.IngestLogEmitter", DummyLog)
 
-    monkeypatch.setattr("core.ingestion.load_documents", lambda p: ["doc"])  # one doc
+    monkeypatch.setattr(
+        "core.ingestion.load_documents", lambda p: [Document(page_content="doc")]
+    )  # one doc
     monkeypatch.setattr(
         "core.ingestion.preprocess_to_documents",
         lambda docs_like, source_path, cfg, doc_type: docs_like,
@@ -131,7 +139,9 @@ def test_ingest_one_background_many_files(tmp_path, monkeypatch):
     monkeypatch.setattr("core.ingestion.is_duplicate_checksum", lambda c, p: False)
     monkeypatch.setattr("core.ingestion.IngestLogEmitter", DummyLog)
 
-    monkeypatch.setattr("core.ingestion.load_documents", lambda p: ["doc"])  # one doc
+    monkeypatch.setattr(
+        "core.ingestion.load_documents", lambda p: [Document(page_content="doc")]
+    )  # one doc
     monkeypatch.setattr(
         "core.ingestion.preprocess_to_documents",
         lambda docs_like, source_path, cfg, doc_type: docs_like,

--- a/tests/test_opensearch_utils.py
+++ b/tests/test_opensearch_utils.py
@@ -75,7 +75,8 @@ def test_index_documents_bulk(monkeypatch):
     monkeypatch.setattr(osu, "ensure_index_exists", lambda: None)
 
     chunks = [{"id": "1", "text": "a"}, {"id": "2", "text": "b"}]
-    osu.index_documents(chunks)
+    resp = osu.index_documents(chunks)
+    assert resp["indexed"] == 2 and resp["errors"] == []
     assert len(recorded["actions"]) == 2
     assert all(a.get("_op_type") == "create" for a in recorded["actions"])
 
@@ -95,7 +96,8 @@ def test_index_documents_update(monkeypatch):
     monkeypatch.setattr(osu, "ensure_index_exists", lambda: None)
 
     chunks = [{"id": "1", "text": "a", "op_type": "update"}]
-    osu.index_documents(chunks)
+    resp = osu.index_documents(chunks)
+    assert resp["indexed"] == 1
     action = recorded["actions"][0]
     assert action["_op_type"] == "update"
     assert action["doc"]["text"] == "a"

--- a/tests/test_opensearch_utils_extra.py
+++ b/tests/test_opensearch_utils_extra.py
@@ -52,9 +52,9 @@ def test_bulk_index_partial_failure(monkeypatch, caplog):
     def fake_bulk(client, actions):
         return (1, ['err'])
     monkeypatch.setattr(osu, 'helpers', types.SimpleNamespace(bulk=fake_bulk))
-    caplog.set_level(logging.ERROR)
+    caplog.set_level(logging.WARNING)
     osu.index_documents([{ 'id':'1','text':'a'}])
-    assert any('OpenSearch indexing failed' in r.message for r in caplog.records)
+    assert any('Bulk indexing completed with some errors' in r.message for r in caplog.records)
 
 
 def test_set_has_embedding_partial_error(monkeypatch):

--- a/tests/test_qdrant_utils.py
+++ b/tests/test_qdrant_utils.py
@@ -2,6 +2,7 @@ import types
 import importlib
 import sys
 from unittest.mock import MagicMock
+import pytest
 
 # Remove stubbed qdrant_client if present and import the real one
 if isinstance(sys.modules.get("qdrant_client"), types.SimpleNamespace):
@@ -64,7 +65,8 @@ def test_index_chunks_success(monkeypatch):
         {"id": 2, "text": "b", "has_embedding": False},
     ]
 
-    assert qdu.index_chunks(chunks) is True
+    resp = qdu.index_chunks(chunks)
+    assert resp["upserted"] == 2
     ec.assert_called_once()
     mock_client.upsert.assert_called_once()
     points = mock_client.upsert.call_args.kwargs["points"]
@@ -84,7 +86,8 @@ def test_index_chunks_embedding_failure(monkeypatch):
 
     chunks = [{"id": 1, "text": "a"}]
 
-    assert qdu.index_chunks(chunks) is False
+    with pytest.raises(Exception):
+        qdu.index_chunks(chunks)
     mock_client.upsert.assert_not_called()
 
 
@@ -97,7 +100,8 @@ def test_index_chunks_upsert_failure(monkeypatch):
 
     chunks = [{"id": 1, "text": "a"}]
 
-    assert qdu.index_chunks(chunks) is False
+    with pytest.raises(Exception):
+        qdu.index_chunks(chunks)
 
 
 def test_count_qdrant_chunks_by_path(monkeypatch):

--- a/tests/test_vector_store_module.py
+++ b/tests/test_vector_store_module.py
@@ -97,7 +97,8 @@ def make_chunk(text, idx, checksum=None):
 
 def test_vector_index_and_retrieve(setup_fake_qdrant):
     chunks = [make_chunk("a", 0), make_chunk("b", 1), make_chunk("c", 2)]
-    assert qdrant_utils.index_chunks(chunks) is True
+    resp = qdrant_utils.index_chunks(chunks)
+    assert resp["upserted"] == 3
     # lower threshold so second vector is included
     vector_store.CHUNK_SCORE_THRESHOLD = 0.0
     results = vector_store.retrieve_top_k("q", top_k=2)


### PR DESCRIPTION
## Summary
- Refine `index_documents` to return detailed results and mirror full-text indexing exception handling
- Raise exceptions from Qdrant `index_chunks` and report upserts
- Log and continue on chunk indexing failures in ingestion paths

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9bcb76780832aacd0df633cc2a6fb