### PR TITLE
Align OpenSearch indexing error handling

### DIFF
--- a/tests/test_opensearch_utils.py
+++ b/tests/test_opensearch_utils.py
@@ -1,12 +1,5 @@
 import os
-import sys
 import types
-
-
-# Stub opensearchpy before importing module under test
-opensearchpy_stub = types.SimpleNamespace(OpenSearch=object, helpers=types.SimpleNamespace(), exceptions=Exception)
-sys.modules.setdefault("opensearchpy", opensearchpy_stub)
-
 import utils.opensearch_utils as osu
 
 
@@ -66,7 +59,7 @@ def test_index_documents_bulk(monkeypatch):
     class FakeClient:
         pass
 
-    def fake_bulk(client, actions):
+    def fake_bulk(client, actions, **kwargs):
         recorded["actions"] = actions
         return (len(actions), [])
 
@@ -86,7 +79,7 @@ def test_index_documents_update(monkeypatch):
     class FakeClient:
         pass
 
-    def fake_bulk(client, actions):
+    def fake_bulk(client, actions, **kwargs):
         recorded["actions"] = actions
         return (len(actions), [])
 

--- a/tests/test_opensearch_utils_extra.py
+++ b/tests/test_opensearch_utils_extra.py
@@ -49,7 +49,7 @@ def test_ensure_index_noop(monkeypatch):
 def test_bulk_index_partial_failure(monkeypatch, caplog):
     client = FakeClient()
     monkeypatch.setattr(osu, 'get_client', lambda: client)
-    def fake_bulk(client, actions):
+    def fake_bulk(client, actions, **kwargs):
         return (1, ['err'])
     monkeypatch.setattr(osu, 'helpers', types.SimpleNamespace(bulk=fake_bulk))
     caplog.set_level(logging.ERROR)


### PR DESCRIPTION
## Summary
- add robust exception handling and result returns to `index_documents`
- catch OpenSearch chunk indexing errors separately during ingestion
- adjust tests for new bulk API call signature

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9cbe3ebc8832a806872e9c9d61236