### PR TITLE
feat: add ingestion interrupt

### DIFF
--- a/tests/ui_apptest/test_ingest_apptest.py
+++ b/tests/ui_apptest/test_ingest_apptest.py
@@ -42,7 +42,7 @@ def test_ingest_success_and_progress(monkeypatch):
 
     progress_updates = []
 
-    def fake_ingest(paths, progress_callback):
+    def fake_ingest(paths, progress_callback=None, stop_event=None):
         progress_callback(0, 2, 0)
         progress_updates.append(0)
         progress_callback(1, 2, 0)


### PR DESCRIPTION
## Summary
- allow ingestion to be interrupted via a stop button on the ingestion page
- add stop-event support to core ingestion logic
- adjust UI tests for new stop-event API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa2782da48832a99b98cec985d14dc