### PR TITLE
Add Celery worker Docker Compose override

### DIFF
--- a/docker/compose.worker.override.yml
+++ b/docker/compose.worker.override.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+
+services:
+  celery:
+    read_only: true
+    tmpfs: ["/tmp", "/var/tmp"]
+    security_opt: ["no-new-privileges:true"]
+    cap_drop: [ALL]
+    user: "1000:1000"
+    environment:
+      - DOC_PATH_MAP=C:/=>/host-c
+      - MAX_INFLIGHT=2
+    volumes:
+      - ./:/app:ro
+      - type: bind
+        source: "C:/"
+        target: /host-c
+        read_only: true
+      - ./logs:/app/logs:rw


### PR DESCRIPTION
## Summary
- keep base stack in root-level `docker-compose.yml`
- add `docker/compose.worker.override.yml` overriding celery service with read-only filesystem, tmpfs, security options, and path mapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae914ee90832a92c43e7ad78440c7