### PR TITLE
Add path mapping helper and file deletion safeguards

### DIFF
--- a/core/file_ops.py
+++ b/core/file_ops.py
@@ -1,0 +1,7 @@
+import os
+from core.safety import require_delete_enabled
+
+
+def delete_file(path: str) -> None:
+    require_delete_enabled()
+    os.remove(path)

--- a/core/paths.py
+++ b/core/paths.py
@@ -1,0 +1,21 @@
+import os
+
+
+def _load_map():
+    spec = os.getenv("DOC_PATH_MAP", "")
+    pairs = []
+    for item in filter(None, (p.strip() for p in spec.split(";"))):
+        host, cont = map(str.strip, item.split("=>", 1))
+        pairs.append((host.replace("\\", "/").rstrip("/"), cont.rstrip("/")))
+    return pairs
+
+
+_PATH_MAP = _load_map()
+
+
+def to_worker_path(path: str) -> str:
+    p = path.replace("\\", "/")
+    for host, cont in _PATH_MAP:
+        if p.lower().startswith(host.lower()):
+            return cont + p[len(host):]
+    return p

--- a/core/safety.py
+++ b/core/safety.py
@@ -1,0 +1,7 @@
+import os
+
+ALLOW_FILE_DELETE = os.getenv("ALLOW_FILE_DELETE", "false").lower() == "true"
+
+def require_delete_enabled():
+    if not ALLOW_FILE_DELETE:
+        raise PermissionError("File deletion is disabled by configuration.")

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -1,0 +1,21 @@
+from typing import Dict, Any
+
+from celery import shared_task
+
+from core.paths import to_worker_path
+from utils.file_utils import compute_checksum as file_checksum
+from core.file_loader import load_documents as load_with_langchain
+
+
+# Placeholder ensure_job_can_start; in a real system this would check job state.
+def ensure_job_can_start(job_id: str, task=None) -> None:
+    pass
+
+
+@shared_task(bind=True, acks_late=True, autoretry_for=(), retry_backoff=True, max_retries=None)
+def ingest_file_task(self, *, job_id: str, path: str) -> Dict[str, Any]:
+    ensure_job_can_start(job_id, task=self)
+    real_path = to_worker_path(path)
+    checksum = file_checksum(real_path)
+    docs = load_with_langchain(real_path)
+    return {"job_id": job_id, "path": real_path, "checksum": checksum, "docs": docs}


### PR DESCRIPTION
## Summary
- add helper to map host file paths into worker container paths
- ensure ingest file task uses mapped paths
- guard file deletion behind environment flag

## Testing
- `python - <<'PY'
from core.paths import to_worker_path
print(to_worker_path('C:/Users/me/a.pdf'))
PY`
- `python - <<'PY'
from core.file_ops import delete_file
try:
    delete_file('/tmp/nope')
except Exception as e:
    print(type(e).__name__, e)
PY`
- `pytest`
- `docker compose -f docker-compose.yml -f docker/compose.worker.override.yml up -d celery` *(fails: command not found)*
- `docker compose -f docker-compose.yml -f docker/compose.worker.override.yml exec celery sh -lc 'echo test > /host-c/__should_fail__ || echo "write blocked ✅"'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaef73db78832ab84079e32f92d4cb