### PR TITLE
Respect CELERY_TASK_QUEUE env for Celery apps

### DIFF
--- a/core/celery_client.py
+++ b/core/celery_client.py
@@ -13,6 +13,10 @@ def get_celery() -> Celery:
     """
     broker = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
     backend = os.getenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/1")
+    queue = os.getenv("CELERY_TASK_QUEUE", "celery")
     app = Celery("document_qa_worker", broker=broker, backend=backend)
-    logger.info("Celery client broker=%s backend=%s", broker, backend)
+    app.conf.task_default_queue = queue
+    logger.info(
+        "Celery client broker=%s backend=%s queue=%s", broker, backend, queue
+    )
     return app

--- a/worker/celery_worker.py
+++ b/worker/celery_worker.py
@@ -4,7 +4,9 @@ import os
 # Connect to Redis (host will be the docker-compose service name)
 broker_url = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
 backend_url = os.getenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/1")
+queue = os.getenv("CELERY_TASK_QUEUE", "celery")
 app = Celery("document_qa_worker", broker=broker_url, backend=backend_url)
+app.conf.task_default_queue = queue
 app.config_from_object("config")
 
 app.autodiscover_tasks(["core"])


### PR DESCRIPTION
## Summary
- Have both Celery client and worker honor `CELERY_TASK_QUEUE`
- Log queue name when creating Celery client

## Testing
- `pytest tests/test_config_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab8b64ddf0832a9a2a37b4b84365ee