### PR TITLE
Simplify job selection UI

### DIFF
--- a/pages/30_Jobs.py
+++ b/pages/30_Jobs.py
@@ -1,7 +1,6 @@
-import uuid
 from pathlib import Path
 import streamlit as st
-from core.job_control import set_state, incr_stat
+from core.job_control import set_state, incr_stat, all_jobs
 from core.job_queue import push_pending
 from core.discovery_filters import should_skip
 from core.job_commands import pause_job, resume_job, cancel_job, stop_job
@@ -11,18 +10,12 @@ from ui.ingest_client import job_stats
 st.set_page_config(page_title="Ingestion Jobs", layout="wide")
 st.title("🧩 Ingestion Jobs")
 
-# --- Pick / create a job ---
-if "job_id" not in st.session_state:
-    st.session_state.job_id = uuid.uuid4().hex[:8]
-
-c1, c2 = st.columns([3, 1])
-with c1:
-    st.text_input("Job ID", key="job_id")
-with c2:
-    if st.button("New Job ID"):
-        st.session_state.job_id = uuid.uuid4().hex[:8]
-
-job_id = st.session_state.job_id
+# --- Select a job ---
+jobs = all_jobs()
+if not jobs:
+    st.info("No ingestion jobs found.")
+    st.stop()
+job_id = st.selectbox("Job", jobs)
 
 # --- Register paths under C:\ ---
 st.subheader("Register files")

--- a/tests/test_job_control_all_jobs.py
+++ b/tests/test_job_control_all_jobs.py
@@ -1,0 +1,11 @@
+from core.job_control import set_state, incr_stat, add_task, all_jobs
+
+
+def test_all_jobs_lists_ids():
+    # populate state, stats and tasks for different jobs
+    set_state("job_state", "running")
+    incr_stat("job_stats", "registered", 1)
+    add_task("job_tasks", "task1")
+
+    jobs = all_jobs()
+    assert set(["job_state", "job_stats", "job_tasks"]).issubset(set(jobs))


### PR DESCRIPTION
## Summary
- replace free-text job ID entry with a dropdown of detected jobs
- expose `all_jobs()` helper to enumerate existing job IDs
- add regression test for `all_jobs`

## Testing
- `pytest` *(fails: DID NOT RAISE <class 'Exception'> in tests/test_ui_env_guard.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac35be53e4832aa8e111cb223e2029