### PR TITLE
Clear pending jobs on cancel/stop and update job stats

### DIFF
--- a/tests/test_job_commands_clear_pending.py
+++ b/tests/test_job_commands_clear_pending.py
@@ -1,0 +1,51 @@
+import core.job_commands as jc
+from core.job_queue import push_pending, pending_len
+
+
+class DummyCelery:
+    def __init__(self):
+        self.control = self
+    def revoke(self, *args, **kwargs):
+        pass
+    def send_task(self, *args, **kwargs):
+        class Result:
+            id = "dummy"
+        return Result()
+
+
+def _setup_pending(job_id: str):
+    push_pending(job_id, "a")
+    push_pending(job_id, "b")
+    assert pending_len(job_id) == 2
+
+
+def test_cancel_job_clears_pending(monkeypatch):
+    job_id = "cancel_pending"
+    _setup_pending(job_id)
+    monkeypatch.setattr(jc, "get_celery", lambda: DummyCelery())
+    jc.cancel_job(job_id)
+    assert pending_len(job_id) == 0
+
+
+def test_pause_job_preserves_pending(monkeypatch):
+    job_id = "pause_pending"
+    _setup_pending(job_id)
+    monkeypatch.setattr(jc, "get_celery", lambda: DummyCelery())
+    jc.pause_job(job_id)
+    assert pending_len(job_id) == 2
+
+
+def test_resume_job_preserves_pending(monkeypatch):
+    job_id = "resume_pending"
+    _setup_pending(job_id)
+    monkeypatch.setattr(jc, "get_celery", lambda: DummyCelery())
+    jc.resume_job(job_id)
+    assert pending_len(job_id) == 2
+
+
+def test_stop_job_clears_pending(monkeypatch):
+    job_id = "stop_pending"
+    _setup_pending(job_id)
+    monkeypatch.setattr(jc, "get_celery", lambda: DummyCelery())
+    jc.stop_job(job_id)
+    assert pending_len(job_id) == 0

--- a/ui/ingest_client.py
+++ b/ui/ingest_client.py
@@ -8,7 +8,7 @@ from typing import Iterable, Dict, Any
 
 from config import logger
 from core.celery_client import get_celery
-from core.job_queue import active_count, retry_count, celery_queue_len
+from core.job_queue import active_count, retry_count, celery_queue_len, pending_len
 from core.job_control import (
     set_state,
     get_state,
@@ -64,10 +64,7 @@ def job_stats(job: str = DEFAULT_JOB_ID) -> Dict[str, Any]:
     stats = get_stats(job)
     active = active_count(job)
     retry = retry_count(job)
-    registered = stats.get("registered", 0)
-    done = stats.get("done", 0)
-    failed = stats.get("failed", 0)
-    pending = max(registered - done - failed - active - retry, 0)
+    pending = pending_len(job)
     return {
         "job_id": job,
         "state": get_state(job),


### PR DESCRIPTION
## Summary
- add `pop_all_pending` helper and use it in job cancel and stop commands
- track pending queue length directly in `job_stats`
- keep pending items when pausing/resuming jobs; only cancel and stop clear the queue
- test job command operations handle pending items as expected

## Testing
- `pytest tests/test_job_commands_clear_pending.py tests/test_job_control_all_jobs.py -q`
- `pytest tests/test_ui_env_guard.py -q` *(fails: DID NOT RAISE <class 'Exception'>)*

------
https://chatgpt.com/codex/tasks/task_e_68ac37c47064832ab7879ffc3c8b05ff