### PR TITLE
Add job and queue cleanup utilities with CLI

### DIFF
--- a/scripts/clear.py
+++ b/scripts/clear.py
@@ -1,0 +1,32 @@
+import argparse
+
+from ui.ingest_client import purge_queue, revoke_job_tasks
+from core.job_queue import clear_job
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Clear job data or purge queues")
+    parser.add_argument("--job", help="Job ID to clear")
+    parser.add_argument("--purge", action="store_true", help="Purge broker queue")
+    parser.add_argument("--queue", default=None, help="Queue name to purge")
+    parser.add_argument(
+        "--terminate", action="store_true", help="Terminate running tasks when revoking"
+    )
+    args = parser.parse_args()
+
+    if args.job:
+        n = revoke_job_tasks(args.job, terminate=args.terminate)
+        print(f"revoked {n} tasks for job {args.job}")
+        counts = clear_job(args.job, terminate=args.terminate)
+        for k, v in counts.items():
+            print(f"removed {v} from {k}")
+    elif args.purge:
+        n = purge_queue(args.queue)
+        qname = args.queue or "celery"
+        print(f"purged {n} messages from queue {qname}")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_job_queue_utils.py
+++ b/tests/test_job_queue_utils.py
@@ -1,0 +1,50 @@
+from core.job_queue import (
+    push_pending,
+    add_active,
+    add_retry,
+    list_jobs,
+    clear_job,
+    pending_count,
+    active_count,
+    retry_count,
+)
+from core.job_control import add_task, pop_all_tasks
+
+
+def test_list_jobs_and_clear_job(monkeypatch):
+    class StubControl:
+        def __init__(self):
+            self.revoked = []
+
+        def revoke(self, task_id, terminate=False):
+            self.revoked.append((task_id, terminate))
+
+    class StubApp:
+        def __init__(self):
+            self.control = StubControl()
+
+    stub_app = StubApp()
+    monkeypatch.setattr("core.celery_client.get_celery", lambda: stub_app)
+
+    job = "jobtest"
+    push_pending(job, "p")
+    add_active(job, "a")
+    add_retry(job, "r")
+    add_task(job, "tid1")
+
+    assert job in list_jobs()
+
+    counts = clear_job(job)
+    assert counts == {
+        "pending": 1,
+        "active": 1,
+        "active_started": 1,
+        "needs_retry": 1,
+        "tasks": 1,
+    }
+    assert pending_count(job) == 0
+    assert active_count(job) == 0
+    assert retry_count(job) == 0
+    assert pop_all_tasks(job) == []
+    assert stub_app.control.revoked == [("tid1", False)]
+    assert job not in list_jobs()

--- a/ui/ingest_client.py
+++ b/ui/ingest_client.py
@@ -4,7 +4,10 @@ heavy worker-only modules.
 """
 from __future__ import annotations
 
+import os
 from typing import Iterable, Dict, Any
+
+import redis
 
 from config import logger
 from core.celery_client import get_celery
@@ -19,6 +22,58 @@ from core.job_control import (
 from core.discovery_filters import should_skip
 
 DEFAULT_JOB_ID = "default"
+
+
+def purge_queue(queue: str | None = None) -> int:
+    """Purge tasks from the broker queue.
+
+    If *queue* is ``None`` or ``"celery"`` the default Celery control purge is
+    used. Otherwise we drain the named queue using Kombu to avoid shelling out.
+    """
+
+    app = get_celery()
+    if queue in (None, "", "celery"):
+        return app.control.purge()
+
+    from kombu import Connection, Queue
+
+    broker_url = os.getenv("CELERY_BROKER_URL")
+    n = 0
+    if not broker_url:
+        return n
+    with Connection(broker_url) as conn:
+        chan = conn.channel()
+        q = Queue(name=queue)
+        while True:
+            msg = chan.basic_get(q.name, no_ack=True)
+            if not msg:
+                break
+            n += 1
+    return n
+
+
+def revoke_job_tasks(job_id: str, terminate: bool = False) -> int:
+    """Revoke any Celery tasks associated with *job_id*.
+
+    Returns the number of tasks revoked. The Redis set is left intact so callers
+    may clear it separately if desired.
+    """
+
+    try:
+        r = redis.from_url(
+            os.getenv("REDIS_URL", "redis://redis:6379/2"),
+            decode_responses=True,
+            socket_connect_timeout=0.1,
+        )
+    except Exception:
+        return 0
+
+    key = f"job:{job_id}:tasks"
+    task_ids = list(r.smembers(key) or [])
+    app = get_celery()
+    for tid in task_ids:
+        app.control.revoke(tid, terminate=terminate)
+    return len(task_ids)
 
 def enqueue_ingest(
     paths: Iterable[str],


### PR DESCRIPTION
## Summary
- add Redis-backed job clearing and listing helpers
- expose Celery queue purge and job task revoke utilities
- provide `scripts/clear.py` CLI for clearing jobs or purging queues
- cover job clearing with unit tests

## Testing
- `pytest tests/test_ui_env_guard.py -q`
- `pytest -k "not ui_env_guard" -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac3cab1f80832aa0328c5f6cea2075