### PR TITLE
Update tests for revised ingestion pipeline

### DIFF
--- a/tests/test_fulltext_reindex.py
+++ b/tests/test_fulltext_reindex.py
@@ -20,13 +20,11 @@ def test_reindex_fulltext_from_chunks(tmp_path, monkeypatch):
     f.write_text("raw")
 
     monkeypatch.setattr(
-        opensearch_utils,
-        "load_documents",
+        "core.file_loader.load_documents",
         lambda p: [Document(page_content="one"), Document(page_content="two")],
     )
     monkeypatch.setattr(
-        opensearch_utils,
-        "preprocess_to_documents",
+        "core.document_preprocessor.preprocess_to_documents",
         lambda docs_like, source_path, cfg, doc_type: [
             Document(page_content="A"),
             Document(page_content="B"),

--- a/tests/test_ingest_api.py
+++ b/tests/test_ingest_api.py
@@ -1,26 +1,42 @@
 import os
-import sys
+from langchain_core.documents import Document
 
-from core.ingestion import ingest
+from core.ingestion import ingest_one
 
 
-def test_ingest_accepts_single_path(tmp_path, monkeypatch):
+def test_ingest_one_returns_normalized_path(tmp_path, monkeypatch):
     sample = tmp_path / "sample.txt"
     sample.write_text("hello")
 
     # Stub out external dependencies used during ingestion
+    monkeypatch.setattr(
+        "core.ingestion.load_documents",
+        lambda p: [Document(page_content="hello", metadata={})],
+    )
+    monkeypatch.setattr(
+        "core.ingestion.preprocess_to_documents",
+        lambda docs_like, source_path, cfg, doc_type: docs_like,
+    )
+    monkeypatch.setattr(
+        "core.ingestion.split_documents", lambda docs: [{"text": "hello"}]
+    )
     monkeypatch.setattr("core.ingestion.index_documents", lambda chunks: None)
     monkeypatch.setattr("utils.qdrant_utils.index_chunks", lambda chunks: True)
-    class DummyApp:
-        def send_task(self, *args, **kwargs):
-            pass
-    monkeypatch.setattr("core.ingestion.celery_app", DummyApp())
     monkeypatch.setattr(
         "core.ingestion.is_file_up_to_date", lambda checksum, path: False
     )
+    monkeypatch.setattr(
+        "core.ingestion.is_duplicate_checksum", lambda checksum, path: False
+    )
+    monkeypatch.setattr(
+        "core.ingestion.index_fulltext_document", lambda doc: None
+    )
+    monkeypatch.setattr(
+        "core.ingestion.set_has_embedding_true_by_ids", lambda ids: (0, 0)
+    )
 
-    result_str = ingest(str(sample))
-    result_list = ingest([str(sample)])
+    result = ingest_one(str(sample))
 
-    assert result_str == result_list
-    assert result_str and result_str[0]["path"] == os.path.normpath(str(sample)).replace("\\", "/")
+    assert result["path"] == os.path.normpath(str(sample)).replace("\\", "/")
+    assert result["success"]
+


### PR DESCRIPTION
## Summary
- update ingestion API tests to use `ingest_one` and stub dependencies
- adjust duplicate ID, fulltext reindex, logging, and UI ingestion tests for new behavior
- remove references to deprecated batching/background constants

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae227f1584832ab9d783e7287d67e9