### PR TITLE
Align tests with updated ingestion and embedding APIs

### DIFF
--- a/tests/test_ingest_fulltext.py
+++ b/tests/test_ingest_fulltext.py
@@ -50,7 +50,10 @@ def test_fulltext_index_called(tmp_path, monkeypatch):
     )
     monkeypatch.setattr("core.ingestion.split_documents", lambda docs: [{"text": "chunk"}])
     monkeypatch.setattr("core.ingestion.index_documents", lambda chunks: None)
-    monkeypatch.setattr("utils.qdrant_utils.index_chunks_in_batches", lambda chunks: False)
+    monkeypatch.setattr(
+        "utils.qdrant_utils.index_chunks_in_batches",
+        lambda chunks, os_index_batch=None: True,
+    )
 
     called = {}
 
@@ -59,9 +62,9 @@ def test_fulltext_index_called(tmp_path, monkeypatch):
 
     monkeypatch.setattr("core.ingestion.index_fulltext_document", fake_index_fulltext)
 
-    with pytest.raises(RuntimeError):
-        ingest_one(str(f))
+    result = ingest_one(str(f))
 
+    assert result["success"] is True
     assert "doc" in called
     assert called["doc"]["text_full"] == "full"
     assert os.path.normpath(called["doc"]["path"]) == os.path.normpath(str(f))

--- a/tests/test_ingest_logging.py
+++ b/tests/test_ingest_logging.py
@@ -59,7 +59,10 @@ def test_duplicate_files_are_indexed_and_logged(monkeypatch, tmp_path):
         "core.ingestion.split_documents", lambda docs: [{"text": "hello"}]
     )
     monkeypatch.setattr("core.ingestion.index_documents", lambda chunks: None)
-    monkeypatch.setattr("utils.qdrant_utils.index_chunks_in_batches", lambda chunks: True)
+    monkeypatch.setattr(
+        "utils.qdrant_utils.index_chunks_in_batches",
+        lambda chunks, os_index_batch=None: True,
+    )
     monkeypatch.setattr("core.ingestion.index_fulltext_document", lambda doc: None)
 
     result = ingestion.ingest_one(str(file_path))

--- a/tests/test_qdrant_utils.py
+++ b/tests/test_qdrant_utils.py
@@ -52,7 +52,7 @@ def test_index_chunks_success(monkeypatch):
     mock_client = MagicMock()
     monkeypatch.setattr(qdu, "client", mock_client)
 
-    def fake_embed(texts):
+    def fake_embed(texts, batch_size=None):
         return [[i, i + 1, i + 2] for i, _ in enumerate(texts)]
 
     monkeypatch.setattr(qdu, "embed_texts", fake_embed)
@@ -72,7 +72,7 @@ def test_index_chunks_embedding_failure(monkeypatch):
     mock_client = MagicMock()
     monkeypatch.setattr(qdu, "client", mock_client)
 
-    def fail_embed(texts):
+    def fail_embed(texts, batch_size=None):
         raise RuntimeError("fail")
 
     monkeypatch.setattr(qdu, "embed_texts", fail_embed)
@@ -88,7 +88,11 @@ def test_index_chunks_upsert_failure(monkeypatch):
     mock_client = MagicMock()
     mock_client.upsert.side_effect = Exception("boom")
     monkeypatch.setattr(qdu, "client", mock_client)
-    monkeypatch.setattr(qdu, "embed_texts", lambda texts: [[0, 0, 0] for _ in texts])
+    monkeypatch.setattr(
+        qdu,
+        "embed_texts",
+        lambda texts, batch_size=None: [[0, 0, 0] for _ in texts],
+    )
 
     chunks = [{"id": 1, "text": "a"}]
 


### PR DESCRIPTION
## Summary
- patch embedding tests to mock session-based HTTP client and adjust error expectation
- update ingestion-related tests for new `index_chunks_in_batches` callback and vector-first flow
- extend qdrant/vector-store mocks to handle `batch_size` and preserve text payloads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b239cbb468832ab3e61c22a9fb87be